### PR TITLE
Feat build rollup external

### DIFF
--- a/renderer/index.js
+++ b/renderer/index.js
@@ -28,17 +28,17 @@ module.exports = function () {
         if (!config.build.rollupOptions) config.build.rollupOptions = {};
         if (!config.build.rollupOptions.output) config.build.rollupOptions.output = {};
 
-				const prodExternals = [...builtinModules.filter(e => !e.startsWith('_')), 'electron'];
+        const prodExternals = [...builtinModules.filter(e => !e.startsWith('_')), 'electron'];
 
-				const modifyOutput = output => {
-					if (!output.format) {
-						// the packaged Electron app should use "cjs"
-						output.format = 'cjs';
-					}
+        const modifyOutput = output => {
+          if (!output.format) {
+            // the packaged Electron app should use "cjs"
+            output.format = 'cjs';
+          }
 
-					// make builtin modules & electron external when rollup
-					output.external = [...(output.external || []), ...prodExternals];
-				};
+          // make builtin modules & electron external when rollup
+          output.external = [...(output.external || []), ...prodExternals];
+        };
         if (Array.isArray(config.build.rollupOptions.output)) {
           config.build.rollupOptions.output.forEach(output => {
             modifyOutput(output);

--- a/renderer/index.js
+++ b/renderer/index.js
@@ -96,7 +96,6 @@ ${exportMembers}
      * @type {ExportCollected}
      */
     const collect = {
-      //
       [moduleId]: {
         alias: { find: new RegExp(`^(node:)?${moduleId}$`) },
         code: nodeModuleCode,


### PR DESCRIPTION
we can use `build.rollupOptions.external` to externalize built in modules & electron.

the `node_modules/.vite-plugin-electron-renderer/fs.js` glue code work when dev (esbuild).
but can cause problem when build (rollup)

like fs-extra > graceful-fs package, without rollup external
will cause error
![image](https://user-images.githubusercontent.com/4067115/162714817-687e5e35-4086-402c-8b8e-05c8af47645a.png)

because 
- raw `require('fs')
- map to `node_modules/.vite-plugin-electron-renderer/fs.js` esmodule
- rollup/plugin-commonjs default use `var require$$0$7 = /* @__PURE__ */ getAugmentedNamespace(fs$o);` 
- the `getAugmentedNamespace` define a getter `close` on `fs`
- so when `graceful-fs` try to overwrite `fs.close`, cause the error present by the image

the error can be prevented by set `{ requireReturnsDefault: 'prefer' / 'auto' }` options of `@rollup/plugin-commonjs` to get rid of `Object.defineProperty`
but it's better to external these modules.

AND background:
https://github.com/magicdawn/magicdawn/issues/132#issuecomment-1094806970
