### PR TITLE
fix: module is not defined

### DIFF
--- a/polyfill-exports/index.js
+++ b/polyfill-exports/index.js
@@ -21,7 +21,7 @@ module.exports = function polyfilleExports() {
 
       // https://github.com/electron-vite/electron-vite-vue/issues/103#issuecomment-1097540635
       if (['cjs', 'commonjs'].includes(format)) {
-        const polyfill = '<script>var exports = module.exports;</script>';
+        const polyfill = '<script>var exports = {};</script>';
         return html.replace(/(<\/[\s\r\n]*?head[\s\r\n]*?>)/, polyfill + '\n$1');
       }
     },

--- a/polyfill-exports/index.js
+++ b/polyfill-exports/index.js
@@ -21,7 +21,7 @@ module.exports = function polyfilleExports() {
 
       // https://github.com/electron-vite/electron-vite-vue/issues/103#issuecomment-1097540635
       if (['cjs', 'commonjs'].includes(format)) {
-        const polyfill = '<script>var exports = {};</script>';
+        const polyfill = '<script>var exports = typeof module !== 'undefined' ? module.exports : {};</script>';
         return html.replace(/(<\/[\s\r\n]*?head[\s\r\n]*?>)/, polyfill + '\n$1');
       }
     },


### PR DESCRIPTION
**fix: module is not defined**

**problem description：**
```js
import polyfillExports from 'vite-plugin-electron/polyfill-exports'
export default {
  plugins: [
    // ...other plugins
    polyfillExports(),
  ],
}
```

```html
<!DOCTYPE html>
<html lang="en">
<head>
  <meta charset="UTF-8" />
  <link rel="icon" href="./favicon.ico" />
  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
  <title>title</title>
  <script type="module" crossorigin src="./index.68c58454.js"></script>
  <link rel="stylesheet" href="./style.80eea33d.css">
<script>var exports = module.exports;</script>
</head>

<body>
  <div id="app"></div>
</body>
</html>
```
<img width="891" alt="image" src="https://user-images.githubusercontent.com/47295879/171583333-7d64f7b5-26d2-412c-93a7-bf6efbb4aa09.png">
