### PR TITLE
v0.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,9 @@
 
 - 394cf6f feat: `config.build.emptyOutDir = false` by default
 - 4a67688 feat(🐞): enabled `polyfill-exports` by default
+
+## [2022-06-07] v0.4.7
+
+- 1346707 refactor: better assign default `build.outDir`
+- f489da1 chore: commnets
+- 6db3bf3 fix: check `output` is Array

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-electron",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Integrate Vite and Electron",
   "main": "dist/index.js",
   "repository": {

--- a/polyfill-exports/index.js
+++ b/polyfill-exports/index.js
@@ -7,6 +7,7 @@ module.exports = function polyfilleExports() {
    * @type {import('vite').ResolvedConfig}
    */
   let config;
+  const formats = ['cjs', 'commonjs'];
 
   return {
     name: 'vite-plugin-electron:polyfill-exports',
@@ -17,11 +18,14 @@ module.exports = function polyfilleExports() {
       const output = config.build.rollupOptions.output;
       if (!output) return;
 
-      const format = Array.isArray(output) ? output.find(e => e.format) : output.format;
-
       // https://github.com/electron-vite/vite-plugin-electron/issues/6
       // https://github.com/electron-vite/vite-plugin-electron/commit/e6decf42164bc1e3801e27984322c41b9c2724b7#r75138942
-      if (['cjs', 'commonjs'].includes(format)) {
+      if (
+        Array.isArray(output)
+          // Once an `output.format` is CJS, it is considered as CommonJs
+          ? output.find(o => formats.includes(o.format))
+          : formats.includes(output.format)
+      ) {
         const polyfill = `<script>var exports = typeof module !== 'undefined' ? module.exports : {};</script>`;
         return html.replace(/(<\/[\s\r\n]*?head[\s\r\n]*?>)/, polyfill + '\n$1');
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ export default function electron(config: Configuration): Plugin[] {
     config(_config) {
       if (!_config.build) _config.build = {}
       if (_config.build.emptyOutDir === undefined) {
-        // Prevent accidental clearing of `dist/electron-main`, `dist/electron-preload`
+        // Prevent accidental clearing of `dist/electron/main`, `dist/electron/preload`
         _config.build.emptyOutDir = false
       }
     },
@@ -41,7 +41,7 @@ export default function electron(config: Configuration): Plugin[] {
       },
       ...opts,
     },
-    // [🐞] exports is not defined 
+    // fix(🐞): exports is not defined 
     polyfillExports(),
   ]
 }


### PR DESCRIPTION
- [refactor: better assign default build.outDir](https://github.com/electron-vite/vite-plugin-electron/commit/41262559edd315a05aecf5745822c23c6a9d6925)
- [chore: commnets](https://github.com/electron-vite/vite-plugin-electron/commit/a5f945f698fec14463e9decde1339a11b8cee687)
- [fix: check output is Array](https://github.com/electron-vite/vite-plugin-electron/commit/a97096d5dc898926c10d612183389ef961e1314d)