### PR TITLE
fix app.getName() return error name

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -55,6 +55,7 @@ export async function bootstrap(config: Configuration, server: ViteDevServer) {
             electronProcess.kill()
           }
 
+          // TODO: Check `package.json` whether the `main` entry in JOSN is correct
           // Start Electron.app
           electronProcess = spawn(electronPath, ['.'], { stdio: 'inherit', env })
           // Exit command after Electron.app exits

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -55,10 +55,8 @@ export async function bootstrap(config: Configuration, server: ViteDevServer) {
             electronProcess.kill()
           }
 
-          // TODO: Check if electronEntry is a directory
-          let electronEntry = path.join(mainConfig.build.outDir, path.parse(config.main.entry).name)
           // Start Electron.app
-          electronProcess = spawn(electronPath, [electronEntry], { stdio: 'inherit', env })
+          electronProcess = spawn(electronPath, ['.'], { stdio: 'inherit', env })
           // Exit command after Electron.app exits
           electronProcess.once('exit', process.exit)
         },


### PR DESCRIPTION
issues #18 

Fix BUG `app.getName()` or `app.getPath()` cannot be used to get the correct path in the main process under the development environment.