### PR TITLE
v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 
+## [2022-07-01] v0.6.2
+
+- 5779397 chore: bump vite-plugin-electron-renderer to 0.5.1
+- 2a2f77d docs: `Put Node.js packages in dependencies`
+
 ## [2022-06-26] v0.6.1
 
 - 5b736fa bump vite-plugin-electron-renderer to 0.5.0

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "vite-plugin-electron-renderer": "^0.5.0"
+    "vite-plugin-electron-renderer": "^0.5.1"
   },
   "devDependencies": {
     "@types/node": "^17.0.31",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-electron",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Integrate Vite and Electron",
   "main": "dist/index.js",
   "repository": {
@@ -21,6 +21,9 @@
     "typescript": "^4.6.4",
     "vite": "^2.9.8"
   },
+  "files": [
+    "dist"
+  ],
   "keywords": [
     "vite",
     "plugin",


### PR DESCRIPTION
- 5779397 chore: bump vite-plugin-electron-renderer to 0.5.1
- 2a2f77d docs: `Put Node.js packages in dependencies`