### PR TITLE
V0.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "engines": {
     "node": "^14.18.0 || >=16.0.0"
   },
+  "packageManager": "pnpm@7.0.0",
   "homepage": "https://github.com/electron-vite/vite-plugin-electron",
   "keywords": [
     "vite",

--- a/packages/electron/CHANGELOG.md
+++ b/packages/electron/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 - 🌱 c8b59ba Support `envFile` options [electron-vite-vue/issues/209](https://github.com/electron-vite/electron-vite-vue/issues/209)
 - 🌱 2d7f033 Add `ImportMeta['env']` declaration
+- 🌱 20d0a22 Must use `pnpm publish` instead of `npm publish` #43
 
 ## [2022-07-25] v0.8.2
 

--- a/packages/electron/CHANGELOG.md
+++ b/packages/electron/CHANGELOG.md
@@ -1,4 +1,9 @@
 
+## [2022-07-31] v0.8.4
+
+- 🌱 c8b59ba Support `envFile` options [electron-vite-vue/issues/209](https://github.com/electron-vite/electron-vite-vue/issues/209)
+- 🌱 2d7f033 Add `ImportMeta['env']` declaration
+
 ## [2022-07-25] v0.8.2
 
 - 9ee720f chore(electron): remove `envFile: false`

--- a/packages/electron/README.md
+++ b/packages/electron/README.md
@@ -40,12 +40,12 @@ export default {
 `electron(config: Configuration)`
 
 ```ts
-import type { LibraryOptions, UserConfig } from 'vite'
+import type { InlineConfig, LibraryOptions } from 'vite'
 import type { InputOption } from 'rollup'
 import { Options } from 'vite-plugin-electron-renderer/plugins/use-node.js'
 
 export interface CommonConfiguration {
-  vite?: UserConfig
+  vite?: InlineConfig
   /**
    * Explicitly include/exclude some CJS modules  
    * `modules` includes `dependencies` of package.json, Node.js's `builtinModules` and `electron`  

--- a/packages/electron/electron-env.d.ts
+++ b/packages/electron/electron-env.d.ts
@@ -10,3 +10,8 @@ declare namespace NodeJS {
     electronApp: import('child_process').ChildProcessWithoutNullStreams
   }
 }
+
+interface ImportMeta {
+  /** shims Vite */
+  env: Record<string, any>
+}

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-electron",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Integrate Vite and Electron",
   "main": "dist/index.js",
   "repository": {

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "dev": "rm -rf dist && tsc --watch",
     "build": "rm -rf dist && tsc",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "node ../../scripts/check-command.js && npm run build"
   },
   "dependencies": {
     "vite-plugin-electron-renderer": "workspace:*"

--- a/packages/electron/src/config.ts
+++ b/packages/electron/src/config.ts
@@ -26,7 +26,7 @@ export function resolveRuntime(
 
 export function resolveBuildConfig(runtime: Runtime): InlineConfig {
   const { proc, config, viteConfig } = runtime
-  const conf: InlineConfig = {
+  const defaultConfig: InlineConfig = {
     // 🚧 Avoid recursive build caused by load config file
     configFile: false,
     publicDir: false,
@@ -41,8 +41,8 @@ export function resolveBuildConfig(runtime: Runtime): InlineConfig {
 
   if (proc === 'preload') {
     // Electron-Preload
-    conf.build.rollupOptions = {
-      ...conf.build.rollupOptions,
+    defaultConfig.build.rollupOptions = {
+      ...defaultConfig.build.rollupOptions,
       input: config[proc].input,
       output: {
         format: 'cjs',
@@ -57,7 +57,7 @@ export function resolveBuildConfig(runtime: Runtime): InlineConfig {
   } else {
     // Electron-Main
     // TODO: consider also support `build.rollupOptions`
-    conf.build.lib = {
+    defaultConfig.build.lib = {
       entry: config[proc].entry,
       formats: ['cjs'],
       fileName: () => '[name].js',
@@ -65,9 +65,9 @@ export function resolveBuildConfig(runtime: Runtime): InlineConfig {
   }
 
   // Assign default dir
-  conf.build.outDir = normalizePath(`${viteConfig.build.outDir}/electron`)
+  defaultConfig.build.outDir = normalizePath(`${viteConfig.build.outDir}/electron`)
 
-  return mergeConfig(conf, config[proc]?.vite || {}) as InlineConfig
+  return mergeConfig(defaultConfig, config[proc]?.vite || {}) as InlineConfig
 }
 
 export function createWithExternal(runtime: Runtime) {

--- a/packages/electron/src/types.ts
+++ b/packages/electron/src/types.ts
@@ -1,9 +1,9 @@
-import type { LibraryOptions, UserConfig } from 'vite'
+import type { InlineConfig, LibraryOptions } from 'vite'
 import type { InputOption } from 'rollup'
 import { Options } from 'vite-plugin-electron-renderer/plugins/use-node.js'
 
 export interface CommonConfiguration {
-  vite?: UserConfig
+  vite?: InlineConfig
   /**
    * Explicitly include/exclude some CJS modules  
    * `modules` includes `dependencies` of package.json, Node.js's `builtinModules` and `electron`  

--- a/scripts/check-command.js
+++ b/scripts/check-command.js
@@ -1,0 +1,7 @@
+
+// /usr/local/lib/node_modules/npm/bin/npm-cli.js
+// /usr/local/lib/node_modules/pnpm/bin/pnpm.cjs
+if (!process.env.npm_execpath.includes('pnpm')) {
+  console.error('🚨 Packages must be published using pnpm.')
+  process.exit(1)
+}


### PR DESCRIPTION
- 🌱 c8b59ba Support `envFile` options [electron-vite-vue/issues/209](https://github.com/electron-vite/electron-vite-vue/issues/209)
- 🌱 2d7f033 Add `ImportMeta['env']` declaration
- 🌱 20d0a22 Must use `pnpm publish` instead of `npm publish`  #43 
