### PR TITLE
fix some bug in v0.8.4

### DIFF
--- a/packages/electron/README.md
+++ b/packages/electron/README.md
@@ -35,6 +35,22 @@ export default {
 }
 ```
 
+you can use `process.env.VITE_DEV_SERVER_URL` when the vite command is called 'serve'
+
+```js
+// electron main.js
+const win = new BrowserWindow({
+  title: 'Main window',
+})
+
+if (process.env.VITE_DEV_SERVER_URL) {
+  win.loadURL(process.env.VITE_DEV_SERVER_URL)
+} else {
+  // load your file
+  win.loadFile('yourOutputFile.html');
+}
+```
+
 ## API
 
 `electron(config: Configuration)`

--- a/packages/electron/electron-env.d.ts
+++ b/packages/electron/electron-env.d.ts
@@ -4,6 +4,7 @@ declare namespace NodeJS {
     NODE_ENV: 'development' | 'production'
     readonly VITE_DEV_SERVER_HOST: string
     readonly VITE_DEV_SERVER_PORT: string
+    readonly VITE_DEV_SERVER_URL: string
   }
 
   interface Process {

--- a/packages/electron/src/config.ts
+++ b/packages/electron/src/config.ts
@@ -30,6 +30,7 @@ export function resolveBuildConfig(runtime: Runtime): InlineConfig {
     // 🚧 Avoid recursive build caused by load config file
     configFile: false,
     publicDir: false,
+    mode: viteConfig.mode,
 
     build: {
       emptyOutDir: false,

--- a/packages/electron/src/index.ts
+++ b/packages/electron/src/index.ts
@@ -1,5 +1,5 @@
 import type { Configuration } from './types'
-import type { Plugin } from 'vite'
+import type { Plugin, ResolvedConfig } from 'vite'
 import { bootstrap } from './serve'
 import { build } from './build'
 import renderer from 'vite-plugin-electron-renderer'
@@ -30,12 +30,19 @@ export default function electron(config: Configuration): Plugin[] {
         })
       },
     },
-    {
-      name: `${name}:build`,
-      apply: 'build',
-      async configResolved(viteConfig) {
-        await build(config, viteConfig)
-      },
-    },
+    ((): Plugin => {
+      let viteConfig: ResolvedConfig
+
+      return {
+        name: `${name}:build`,
+        apply: 'build',
+        configResolved(config) {
+          viteConfig = config
+        },
+        async closeBundle() {
+          await build(config, viteConfig)
+        }
+      }
+    })()
   ]
 }

--- a/packages/electron/src/serve.ts
+++ b/packages/electron/src/serve.ts
@@ -15,6 +15,44 @@ import {
   checkPkgMain,
 } from './config'
 
+export const loopbackHosts = new Set([
+  'localhost',
+  '127.0.0.1',
+  '::1',
+  '0000:0000:0000:0000:0000:0000:0000:0001'
+])
+
+export const wildcardHosts = new Set([
+  '0.0.0.0',
+  '::',
+  '0000:0000:0000:0000:0000:0000:0000:0000'
+])
+
+function resolveHostname(hostname: string) {
+  return loopbackHosts.has(hostname) || wildcardHosts.has(hostname) ? 'localhost' : hostname
+}
+
+function resolveEnv(server: ViteDevServer) {
+  const addressInfo = server.httpServer.address()
+  const isAddressInfo = (x: any): x is AddressInfo => x?.address
+
+  if (isAddressInfo(addressInfo)) {
+    const { address, port } = addressInfo
+    const host = resolveHostname(address)
+
+    const options = server.config.server
+    const protocol = options.https ? 'https' : 'http'
+    const devBase = server.config.base
+
+    const path = typeof options.open === 'string' ? options.open : devBase
+    const url = path.startsWith('http')
+        ? path
+        : `${protocol}://${host}:${port}${path}`
+
+    return { url, host, port }
+  }
+}
+
 export async function bootstrap(config: Configuration, server: ViteDevServer) {
   const electronPath = require('electron')
   const { config: viteConfig } = server
@@ -23,50 +61,50 @@ export async function bootstrap(config: Configuration, server: ViteDevServer) {
   if (config.preload) {
     const preloadRuntime = resolveRuntime('preload', config, viteConfig)
     const preloadConfig = mergeConfig(
-      resolveBuildConfig(preloadRuntime),
       {
-        mode: 'development',
         build: {
           watch: true,
         },
         plugins: [{
           name: 'electron-preload-watcher',
-          writeBundle() {
+          closeBundle() {
             server.ws.send({ type: 'full-reload' })
           },
         }],
       } as UserConfig,
+      resolveBuildConfig(preloadRuntime),
     ) as InlineConfig
 
     await viteBuild(createWithExternal(preloadRuntime)(preloadConfig))
   }
 
   // ---- Electron-Main ----
-  const address = server.httpServer.address() as AddressInfo
-  const env = Object.assign(process.env, {
-    VITE_DEV_SERVER_HOST: address.address,
-    VITE_DEV_SERVER_PORT: address.port,
-  })
+  const env = resolveEnv(server)
+  if (env) {
+    Object.assign(process.env, {
+      VITE_DEV_SERVER_URL: env.url,
+      VITE_DEV_SERVER_HOST: env.host,
+      VITE_DEV_SERVER_PORT: env.port,
+    })
+  }
 
   const mainRuntime = resolveRuntime('main', config, viteConfig)
   const mainConfig = mergeConfig(
-    resolveBuildConfig(mainRuntime),
     {
-      mode: 'development',
       build: {
         watch: true,
       },
       plugins: [
         {
           name: 'electron-main-watcher',
-          writeBundle() {
+          closeBundle() {
             if (process.electronApp) {
               process.electronApp.removeAllListeners()
               process.electronApp.kill()
             }
 
             // Start Electron.app
-            process.electronApp = spawn(electronPath, ['.'], { stdio: 'inherit', env })
+            process.electronApp = spawn(electronPath, ['.'], { stdio: 'inherit', env: process.env })
             // Exit command after Electron.app exits
             process.electronApp.once('exit', process.exit)
           },
@@ -74,6 +112,7 @@ export async function bootstrap(config: Configuration, server: ViteDevServer) {
         checkPkgMain.buildElectronMainPlugin(mainRuntime),
       ],
     } as UserConfig,
+    resolveBuildConfig(mainRuntime),
   ) as InlineConfig
 
   await viteBuild(createWithExternal(mainRuntime)(mainConfig))


### PR DESCRIPTION
1. feat: add `VITE_DEV_SERVER_URL` to electron
process env, so that it is easier to use

2. fix(🐞): VITE_DEV_SERVER_HOST cannot be used directly when
VITE_DEV_SERVER_HOST is a ipv6 address or
vite config `server.host` is true

3. fix(🐞): use vite config `mode` as default build
mode to avoid build mode not equal to vite config `mode` when
vite config `mode` !== 'development' which would lead to render env
not equal to electron main or preload

4. fix(🐞): build electron output after render to avoid the electron
output being deleted when the vite config emptyOutDir
is `true` and the vite command is `build`

5. fix(🐞): use `closeBundle` to replace `writeBundle`, because in
extreme cases, an error will be reported. For example,
`can't find preload module` will occur as an error
when `preload` update frequently