### PR TITLE
V0.9.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,4 +109,5 @@ package-lock.json
 # pnpm-lock.yaml
 yarn.lock
 
+release
 packages/electron-renderer/plugins

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,4 @@
 
 #### vite-plugin-electron-renderer
 
-- ebc6a3d chore(electron-renderer): remove `renderBuiltUrl()` based on vite@3.0.6
+- ebc6a3d chore(electron-renderer): remove `renderBuiltUrl()` based on vite@3.0.6 ([vite@3.0.6-8f2065e](https://github.com/vitejs/vite/pull/9381/commits/8f2065efcb6ba664f7dce6f3c7666b29e2c56027#diff-aa53520bfd53e6c24220c44494457cc66370fd2bee513c15f9be7eb537a363e7L874))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+## 0.9.0 (2022-08-12)
+
+🎉 `v0.9.0` is a stable version based on `vite@3.0.6`
+
+#### vite-plugin-electron
+
+#### vite-plugin-electron-renderer
+
+- ebc6a3d chore(electron-renderer): remove `renderBuiltUrl()` based on vite@3.0.6

--- a/packages/electron-renderer/package.json
+++ b/packages/electron-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-electron-renderer",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "description": "Support use Node.js API in Electron-Renderer",
   "main": "plugins/index.js",
   "repository": {

--- a/packages/electron-renderer/package.json
+++ b/packages/electron-renderer/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "vite": "^3.0.2"
+    "vite": "^3.0.6"
   },
   "files": [
     "plugins"

--- a/packages/electron-renderer/src/build-config.ts
+++ b/packages/electron-renderer/src/build-config.ts
@@ -1,40 +1,4 @@
-import path from 'path'
 import type { Plugin } from 'vite'
-
-// https://github.com/vitejs/vite/blob/main/packages/vite/src/node/constants.ts#L84-L124
-const KNOWN_ASSET_TYPES = [
-  // images
-  'png',
-  'jpe?g',
-  'jfif',
-  'pjpeg',
-  'pjp',
-  'gif',
-  'svg',
-  'ico',
-  'webp',
-  'avif',
-
-  // media
-  'mp4',
-  'webm',
-  'ogg',
-  'mp3',
-  'wav',
-  'flac',
-  'aac',
-
-  // fonts
-  'woff2?',
-  'eot',
-  'ttf',
-  'otf',
-
-  // other
-  'webmanifest',
-  'pdf',
-  'txt'
-]
 
 export default function buildConfig(): Plugin {
   return {
@@ -58,22 +22,6 @@ export default function buildConfig(): Plugin {
 
       // prevent accidental clearing of `dist/electron/main`, `dist/electron/preload`
       if (config.build.emptyOutDir === undefined) config.build.emptyOutDir = false
-
-      // `Uncaught TypeError: Failed to construct 'URL': Invalid URL` #44
-      if (!config.experimental) config.experimental = {
-        renderBuiltUrl(filename, type) {
-          if (
-            KNOWN_ASSET_TYPES.includes(path.extname(filename).slice(1)) &&
-            type.hostType === 'js'
-          ) {
-            // Avoid Vite relative-path assets handling
-            // https://github.com/vitejs/vite/blob/89dd31cfe228caee358f4032b31fdf943599c842/packages/vite/src/node/build.ts#L850-L862
-            return { runtime: JSON.stringify(filename) }
-          }
-          // TODO: replace `config.build.assetsDir` for chunk js
-          // TODO: replace `config.build.assetsDir` for split css
-        },
-      }
     },
   }
 }

--- a/packages/electron-renderer/src/build-config.vite-3.0.5.ts
+++ b/packages/electron-renderer/src/build-config.vite-3.0.5.ts
@@ -1,0 +1,81 @@
+import path from 'path'
+import type { Plugin } from 'vite'
+
+// https://github.com/vitejs/vite/blob/main/packages/vite/src/node/constants.ts#L84-L124
+const KNOWN_ASSET_TYPES = [
+  // images
+  'png',
+  'jpe?g',
+  'jfif',
+  'pjpeg',
+  'pjp',
+  'gif',
+  'svg',
+  'ico',
+  'webp',
+  'avif',
+
+  // media
+  'mp4',
+  'webm',
+  'ogg',
+  'mp3',
+  'wav',
+  'flac',
+  'aac',
+
+  // fonts
+  'woff2?',
+  'eot',
+  'ttf',
+  'otf',
+
+  // other
+  'webmanifest',
+  'pdf',
+  'txt'
+]
+
+export default function buildConfig(): Plugin {
+  return {
+    name: 'vite-plugin-electron-renderer:build-config',
+    apply: 'build',
+    config(config) {
+      // make sure that Electron can be loaded into the local file using `loadFile` after packaging
+      if (config.base === undefined) config.base = './'
+
+      if (config.build === undefined) config.build = {}
+
+      // TODO: init `config.build.target`
+      // https://github.com/vitejs/vite/pull/8843
+
+      // ensure that static resources are loaded normally
+      // TODO: Automatic splicing `build.assetsDir`
+      if (config.build.assetsDir === undefined) config.build.assetsDir = ''
+
+      // https://github.com/electron-vite/electron-vite-vue/issues/107
+      if (config.build.cssCodeSplit === undefined) config.build.cssCodeSplit = false
+
+      // prevent accidental clearing of `dist/electron/main`, `dist/electron/preload`
+      if (config.build.emptyOutDir === undefined) config.build.emptyOutDir = false
+
+      // `Uncaught TypeError: Failed to construct 'URL': Invalid URL` #44
+      // `vite@3.0.6` fixed this BUG 🐞
+      // https://github.com/vitejs/vite/pull/9381/commits/8f2065efcb6ba664f7dce6f3c7666b29e2c56027#diff-aa53520bfd53e6c24220c44494457cc66370fd2bee513c15f9be7eb537a363e7L874
+      if (!config.experimental) config.experimental = {
+        renderBuiltUrl(filename, type) {
+          if (
+            KNOWN_ASSET_TYPES.includes(path.extname(filename).slice(1)) &&
+            type.hostType === 'js'
+          ) {
+            // Avoid Vite relative-path assets handling
+            // https://github.com/vitejs/vite/blob/89dd31cfe228caee358f4032b31fdf943599c842/packages/vite/src/node/build.ts#L850-L862
+            return { runtime: JSON.stringify(filename) }
+          }
+          // TODO: replace `config.build.assetsDir` for chunk js
+          // TODO: replace `config.build.assetsDir` for split css
+        },
+      }
+    },
+  }
+}

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-electron",
-  "version": "0.8.8",
+  "version": "0.9.0",
   "description": "Integrate Vite and Electron",
   "main": "dist/index.js",
   "repository": {

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -19,7 +19,7 @@
     "vite-plugin-electron-renderer": "workspace:*"
   },
   "devDependencies": {
-    "vite": "^3.0.2",
+    "vite": "^3.0.6",
     "rollup": "^2.77.0"
   },
   "files": [

--- a/playground/usecase-in-main/electron-builder.json5
+++ b/playground/usecase-in-main/electron-builder.json5
@@ -1,0 +1,37 @@
+/**
+ * @see https://www.electron.build/configuration/configuration
+ */
+{
+  appId: "YourAppID",
+  productName: "YourAppName",
+  copyright: "Copyright © 2022 ${author}",
+  asar: false,
+  directories: {
+    output: "release/${version}",
+    buildResources: "electron/resources",
+  },
+  files: ["dist"],
+  win: {
+    target: [
+      {
+        target: "nsis",
+        arch: ["x64"],
+      },
+    ],
+    artifactName: "${productName}-Windows-${version}-Setup.${ext}",
+  },
+  nsis: {
+    oneClick: false,
+    perMachine: false,
+    allowToChangeInstallationDirectory: true,
+    deleteAppDataOnUninstall: false,
+  },
+  mac: {
+    target: ["dmg"],
+    artifactName: "${productName}-Mac-${version}-Installer.${ext}",
+  },
+  linux: {
+    target: ["AppImage"],
+    artifactName: "${productName}-Linux-${version}.${ext}",
+  },
+}

--- a/playground/usecase-in-main/package.json
+++ b/playground/usecase-in-main/package.json
@@ -5,10 +5,10 @@
   "main": "dist/electron/main/index.js",
   "scripts": {
     "dev": "vite",
-    "build": "vue-tsc --noEmit && vite build && electron-builder"
+    "build": "vite build && electron-builder"
   },
   "keywords": [],
-  "author": "",
+  "author": "草鞋没号 <308487730@qq.com>",
   "license": "ISC",
   "dependencies": {
     "serialport": "^10.4.0",
@@ -24,6 +24,6 @@
     "node-fetch": "^3.2.8",
     "vite-plugin-electron": "workspace:*",
     "vite-plugin-esmodule": "^1.4.1",
-    "vite": "^3.0.2"
+    "vite": "^3.0.6"
   }
 }

--- a/playground/usecase-in-main/vite.config.ts
+++ b/playground/usecase-in-main/vite.config.ts
@@ -1,6 +1,9 @@
+import fs from 'fs'
 import path from 'path'
 import { defineConfig } from 'vite'
 import electron from 'vite-plugin-electron'
+
+fs.rmSync('dist', { recursive: true, force: true })
 
 export default defineConfig({
   plugins: [
@@ -10,6 +13,7 @@ export default defineConfig({
         vite: {
           build: {
             outDir: 'dist/electron/main',
+            minify: false,
           },
         },
       },
@@ -23,9 +27,13 @@ export default defineConfig({
             // For debug
             sourcemap: 'inline',
             outDir: 'dist/electron/preload',
+            minify: false,
           },
         },
       },
     }),
   ],
+  build: {
+    minify: false,
+  },
 })

--- a/playground/usecase-in-renderer/electron-builder.json5
+++ b/playground/usecase-in-renderer/electron-builder.json5
@@ -1,0 +1,37 @@
+/**
+ * @see https://www.electron.build/configuration/configuration
+ */
+{
+  appId: "YourAppID",
+  productName: "YourAppName",
+  copyright: "Copyright © 2022 ${author}",
+  asar: false,
+  directories: {
+    output: "release/${version}",
+    buildResources: "electron/resources",
+  },
+  files: ["dist"],
+  win: {
+    target: [
+      {
+        target: "nsis",
+        arch: ["x64"],
+      },
+    ],
+    artifactName: "${productName}-Windows-${version}-Setup.${ext}",
+  },
+  nsis: {
+    oneClick: false,
+    perMachine: false,
+    allowToChangeInstallationDirectory: true,
+    deleteAppDataOnUninstall: false,
+  },
+  mac: {
+    target: ["dmg"],
+    artifactName: "${productName}-Mac-${version}-Installer.${ext}",
+  },
+  linux: {
+    target: ["AppImage"],
+    artifactName: "${productName}-Linux-${version}.${ext}",
+  },
+}

--- a/playground/usecase-in-renderer/electron/main.ts
+++ b/playground/usecase-in-renderer/electron/main.ts
@@ -5,7 +5,7 @@ process.env['ELECTRON_DISABLE_SECURITY_WARNINGS'] = 'true'
 
 export const ROOT_PATH = {
   // /dist
-  dist: path.join(__dirname, '../..'),
+  dist: path.join(__dirname, '..'),
   // /dist or /public
   public: path.join(__dirname, app.isPackaged ? '../..' : '../../../public'),
 }

--- a/playground/usecase-in-renderer/package.json
+++ b/playground/usecase-in-renderer/package.json
@@ -5,10 +5,10 @@
   "main": "dist/electron/main.js",
   "scripts": {
     "dev": "vite",
-    "build": "vue-tsc --noEmit && vite build && electron-builder"
+    "build": "vite build && electron-builder"
   },
   "keywords": [],
-  "author": "",
+  "author": "草鞋没号 <308487730@qq.com>",
   "license": "ISC",
   "dependencies": {
     "serialport": "^10.4.0",
@@ -24,6 +24,6 @@
     "node-fetch": "^3.2.8",
     "vite-plugin-electron": "workspace:*",
     "vite-plugin-esmodule": "^1.4.1",
-    "vite": "^3.0.2"
+    "vite": "^3.0.6"
   }
 }

--- a/playground/usecase-in-renderer/vite.config.ts
+++ b/playground/usecase-in-renderer/vite.config.ts
@@ -1,16 +1,29 @@
+import fs from 'fs'
 import path from 'path'
 import { defineConfig } from 'vite'
 import electron from 'vite-plugin-electron'
 import esmodule from 'vite-plugin-esmodule'
+
+fs.rmSync('dist', { recursive: true, force: true })
 
 export default defineConfig({
   plugins: [
     electron({
       main: {
         entry: 'electron/main.ts',
+        vite: {
+          build: {
+            minify: false,
+          },
+        },
       },
       preload: {
         input: path.join(__dirname, 'electron/preload.ts'),
+        vite: {
+          build: {
+            minify: false,
+          },
+        },
       },
       // Enables use of Node.js API in the Renderer-process
       renderer: {
@@ -22,5 +35,8 @@ export default defineConfig({
       },
     }),
     esmodule(['execa', 'got', 'node-fetch']),
-  ]
+  ],
+  build: {
+    minify: false,
+  },
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,19 +13,19 @@ importers:
   packages/electron:
     specifiers:
       rollup: ^2.77.0
-      vite: ^3.0.2
+      vite: ^3.0.6
       vite-plugin-electron-renderer: workspace:*
     dependencies:
       vite-plugin-electron-renderer: link:../electron-renderer
     devDependencies:
       rollup: 2.77.0
-      vite: 3.0.2
+      vite: 3.0.6
 
   packages/electron-renderer:
     specifiers:
-      vite: ^3.0.2
+      vite: ^3.0.6
     devDependencies:
-      vite: 3.0.2
+      vite: 3.0.6
 
   playground/usecase-in-main:
     specifiers:
@@ -38,7 +38,7 @@ importers:
       node-fetch: ^3.2.8
       serialport: ^10.4.0
       sqlite3: ^5.0.9
-      vite: ^3.0.2
+      vite: ^3.0.6
       vite-plugin-electron: workspace:*
       vite-plugin-esmodule: ^1.4.1
     dependencies:
@@ -52,9 +52,17 @@ importers:
       execa: 6.1.0
       got: 12.1.0
       node-fetch: 3.2.8
-      vite: 3.0.2
+      vite: 3.0.6
       vite-plugin-electron: link:../../packages/electron
       vite-plugin-esmodule: 1.4.1
+
+  playground/usecase-in-main/release/0.0.0/mac/YourAppName.app/Contents/Resources/app:
+    specifiers:
+      serialport: ^10.4.0
+      sqlite3: ^5.0.9
+    dependencies:
+      serialport: 10.4.0
+      sqlite3: 5.0.9
 
   playground/usecase-in-renderer:
     specifiers:
@@ -67,7 +75,7 @@ importers:
       node-fetch: ^3.2.8
       serialport: ^10.4.0
       sqlite3: ^5.0.9
-      vite: ^3.0.2
+      vite: ^3.0.6
       vite-plugin-electron: workspace:*
       vite-plugin-esmodule: ^1.4.1
     dependencies:
@@ -81,9 +89,17 @@ importers:
       execa: 6.1.0
       got: 12.1.0
       node-fetch: 3.2.8
-      vite: 3.0.2
+      vite: 3.0.6
       vite-plugin-electron: link:../../packages/electron
       vite-plugin-esmodule: 1.4.1
+
+  playground/usecase-in-renderer/release/0.0.0/mac/YourAppName.app/Contents/Resources/app:
+    specifiers:
+      serialport: ^10.4.0
+      sqlite3: ^5.0.9
+    dependencies:
+      serialport: 10.4.0
+      sqlite3: 5.0.9
 
 packages:
 
@@ -2892,8 +2908,8 @@ packages:
       xmlbuilder: 15.1.1
     dev: true
 
-  /postcss/8.4.14:
-    resolution: {integrity: sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==}
+  /postcss/8.4.16:
+    resolution: {integrity: sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
       nanoid: 3.3.4
@@ -3585,8 +3601,8 @@ packages:
     resolution: {integrity: sha512-hTY1pdtSmN/BNOnjvmcmK+2fW1Ac9wD0gFBy67i5IsKwhr1fS1/GGmssdCaik2SpnplHjoDrmCgVsgBv20HzrA==}
     dev: true
 
-  /vite/3.0.2:
-    resolution: {integrity: sha512-TAqydxW/w0U5AoL5AsD9DApTvGb2iNbGs3sN4u2VdT1GFkQVUfgUldt+t08TZgi23uIauh1TUOQJALduo9GXqw==}
+  /vite/3.0.6:
+    resolution: {integrity: sha512-pjfsWIzfUlQME/VAmU6SsjdHkTt6WAHysuqPkHDcjzNu6IGtxDSZ/VfRYOwHaCqX4M3Ivz0kxuSfAPM6gAIX+w==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
     peerDependencies:
@@ -3605,7 +3621,7 @@ packages:
         optional: true
     dependencies:
       esbuild: 0.14.49
-      postcss: 8.4.14
+      postcss: 8.4.16
       resolve: 1.22.1
       rollup: 2.77.0
     optionalDependencies:


### PR DESCRIPTION
🎉 `v0.9.0` is a stable version based on `vite@3.0.6`

- based on `vite@3.0.6` (0085d1d)
- remove `config.experimental.renderBuiltUrl(filename, type)`, because it fixed in [vite@3.0.6-8f2065e](https://github.com/vitejs/vite/pull/9381/commits/8f2065efcb6ba664f7dce6f3c7666b29e2c56027#diff-aa53520bfd53e6c24220c44494457cc66370fd2bee513c15f9be7eb537a363e7L874)  (ebc6a3d)