### PR TITLE
Enable --no-sandbox flag

### DIFF
--- a/packages/electron/src/serve.ts
+++ b/packages/electron/src/serve.ts
@@ -104,7 +104,7 @@ export async function bootstrap(config: Configuration, server: ViteDevServer) {
             }
 
             // Start Electron.app
-            process.electronApp = spawn(electronPath, ['.'], { stdio: 'inherit', env: process.env })
+            process.electronApp = spawn(electronPath, ['.', '--no-sandbox'], { stdio: 'inherit', env: process.env })
             // Exit command after Electron.app exits
             process.electronApp.once('exit', process.exit)
           },


### PR DESCRIPTION
On some Linux distributions the task won't work without the --no-sandbox flag.

https://github.com/electron/electron/issues/18265
https://github.com/nklayman/vue-cli-plugin-electron-builder/pull/732

![Screenshot from 2022-08-24 00-13-20](https://user-images.githubusercontent.com/37969970/186210321-d8a390d8-42a1-4f9b-939b-5b272318683a.png)
