### PR TITLE
V0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.9.1 (2022-08-24)
+
+#### vite-plugin-electron
+
+- db61e49 feat(electron): support custom start 🌱 | #57, #58
+
+#### vite-plugin-electron-renderer
+
 ## 0.9.0 (2022-08-12)
 
 🎉 `v0.9.0` is a stable version based on `vite@3.0.6`

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-electron",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Integrate Vite and Electron",
   "main": "dist/index.js",
   "repository": {

--- a/packages/electron/src/index.ts
+++ b/packages/electron/src/index.ts
@@ -1,12 +1,15 @@
 import type { Configuration } from './types'
 import type { Plugin, ResolvedConfig } from 'vite'
-import { bootstrap } from './serve'
+import { bootstrap, onstart } from './serve'
 import { build } from './build'
 import renderer from 'vite-plugin-electron-renderer'
 import buildConfig from 'vite-plugin-electron-renderer/plugins/build-config'
 
-export { Configuration }
-
+// public export
+export {
+  type Configuration,
+  onstart,
+}
 export function defineConfig(config: Configuration) {
   return config
 }

--- a/packages/electron/src/serve.ts
+++ b/packages/electron/src/serve.ts
@@ -104,7 +104,7 @@ export async function bootstrap(config: Configuration, server: ViteDevServer) {
             }
 
             // Start Electron.app
-            process.electronApp = spawn(electronPath, ['.'], { stdio: 'inherit', env: process.env })
+            process.electronApp = spawn(electronPath, ['.', '--no-sandbox'], { stdio: 'inherit', env: process.env })
             // Exit command after Electron.app exits
             process.electronApp.once('exit', process.exit)
           },

--- a/packages/electron/src/serve.ts
+++ b/packages/electron/src/serve.ts
@@ -104,7 +104,7 @@ export async function bootstrap(config: Configuration, server: ViteDevServer) {
             }
 
             // Start Electron.app
-            process.electronApp = spawn(electronPath, ['.', '--no-sandbox'], { stdio: 'inherit', env: process.env })
+            process.electronApp = spawn(electronPath, ['.', '--no-sandbox'], { stdio: 'inherit' })
             // Exit command after Electron.app exits
             process.electronApp.once('exit', process.exit)
           },

--- a/packages/electron/src/serve.ts
+++ b/packages/electron/src/serve.ts
@@ -46,8 +46,8 @@ function resolveEnv(server: ViteDevServer) {
 
     const path = typeof options.open === 'string' ? options.open : devBase
     const url = path.startsWith('http')
-        ? path
-        : `${protocol}://${host}:${port}${path}`
+      ? path
+      : `${protocol}://${host}:${port}${path}`
 
     return { url, host, port }
   }
@@ -63,7 +63,7 @@ export async function bootstrap(config: Configuration, server: ViteDevServer) {
     const preloadConfig = mergeConfig(
       {
         build: {
-          watch: true,
+          watch: {},
         },
         plugins: [{
           name: 'electron-preload-watcher',
@@ -92,7 +92,7 @@ export async function bootstrap(config: Configuration, server: ViteDevServer) {
   const mainConfig = mergeConfig(
     {
       build: {
-        watch: true,
+        watch: {},
       },
       plugins: [
         {

--- a/packages/electron/src/serve.ts
+++ b/packages/electron/src/serve.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'child_process'
 import type { AddressInfo } from 'net'
 import {
+  type Plugin,
   type ViteDevServer,
   type UserConfig,
   type InlineConfig,
@@ -50,6 +51,23 @@ function resolveEnv(server: ViteDevServer) {
       : `${protocol}://${host}:${port}${path}`
 
     return { url, host, port }
+  }
+}
+
+/**
+ * Custom start plugin
+ */
+export function onstart(onstart?: () => void): Plugin {
+  return {
+    name: 'electron-custom-start',
+    configResolved(config) {
+      const index = config.plugins.findIndex(p => p.name === 'electron-main-watcher')
+        // At present, Vite can only modify plugins in configResolved hook.
+        ; (config.plugins as Plugin[]).splice(index, 1)
+    },
+    closeBundle() {
+      onstart?.()
+    },
   }
 }
 

--- a/playground/usecase-in-main/electron-env.d.ts
+++ b/playground/usecase-in-main/electron-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite-plugin-electron/electron-env" />

--- a/playground/usecase-in-main/tsconfig.json
+++ b/playground/usecase-in-main/tsconfig.json
@@ -16,5 +16,5 @@
     "noImplicitReturns": true,
     "skipLibCheck": true
   },
-  "include": ["src"]
+  "include": ["src", "electron-env.d.ts", "vite.config.ts"]
 }

--- a/playground/usecase-in-main/vite.config.ts
+++ b/playground/usecase-in-main/vite.config.ts
@@ -1,7 +1,9 @@
 import fs from 'fs'
 import path from 'path'
+import { spawn } from 'child_process'
 import { defineConfig } from 'vite'
-import electron from 'vite-plugin-electron'
+import electron, { onstart } from 'vite-plugin-electron'
+import electronPath from 'electron'
 
 fs.rmSync('dist', { recursive: true, force: true })
 
@@ -15,6 +17,19 @@ export default defineConfig({
             outDir: 'dist/electron/main',
             minify: false,
           },
+          plugins: [
+            onstart(() => {
+              if (process.electronApp) {
+                process.electronApp.removeAllListeners()
+                process.electronApp.kill()
+              }
+  
+              // Start Electron.app
+              process.electronApp = spawn(electronPath, ['.', '--no-sandbox'], { stdio: 'inherit' })
+              // Exit command after Electron.app exits
+              process.electronApp.once('exit', process.exit)
+            }),
+          ],
         },
       },
       preload: {

--- a/playground/usecase-in-renderer/electron-env.d.ts
+++ b/playground/usecase-in-renderer/electron-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite-plugin-electron/electron-env" />

--- a/playground/usecase-in-renderer/tsconfig.json
+++ b/playground/usecase-in-renderer/tsconfig.json
@@ -16,5 +16,5 @@
     "noImplicitReturns": true,
     "skipLibCheck": true
   },
-  "include": ["src"]
+  "include": ["src", "electron-env.d.ts", "vite.config.ts"]
 }


### PR DESCRIPTION
About `v0.9.1`

- db61e49 feat(electron): support custom start 🌱 | #57

Custom start

```ts
import electron, { onstart } from 'vite-plugin-electron'
import electronPath from 'electron'

export default {
  plugins: [
    electron({
      main: {
        entry: 'electron/main/index.ts',
        vite: {
          plugins: [
            onstart(() => {
              if (process.electronApp) {
                process.electronApp.removeAllListeners()
                process.electronApp.kill()
              }
  
              // Start Electron.app
              process.electronApp = spawn(electronPath, ['.', '--no-sandbox'], { stdio: 'inherit' })
              // Exit command after Electron.app exits
              process.electronApp.once('exit', process.exit)
            }),
          ],
        },
      },
    }),
  ],
}
```

@SupianIDz 