### PR TITLE
V0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,25 @@
+## 0.9.2 (2022-08-29)
+
+*vite-plugin-electron*
+
+- 715a1cd fix(electron): `VITE_DEV_SERVER_HOSTNAME` instead `VITE_DEV_SERVER_HOST`
+
+*vite-plugin-electron-renderer*
+
 ## 0.9.1 (2022-08-24)
 
-#### vite-plugin-electron
+*vite-plugin-electron*
 
 - db61e49 feat(electron): support custom start 🌱 | #57, #58
 
-#### vite-plugin-electron-renderer
+~~*vite-plugin-electron-renderer*~~
 
 ## 0.9.0 (2022-08-12)
 
 🎉 `v0.9.0` is a stable version based on `vite@3.0.6`
 
-#### vite-plugin-electron
+~~*vite-plugin-electron*~~
 
-#### vite-plugin-electron-renderer
+*vite-plugin-electron-renderer*
 
 - ebc6a3d chore(electron-renderer): remove `renderBuiltUrl()` based on vite@3.0.6 ([vite@3.0.6-8f2065e](https://github.com/vitejs/vite/pull/9381/commits/8f2065efcb6ba664f7dce6f3c7666b29e2c56027#diff-aa53520bfd53e6c24220c44494457cc66370fd2bee513c15f9be7eb537a363e7L874))

--- a/packages/electron/CHANGELOG.md
+++ b/packages/electron/CHANGELOG.md
@@ -18,8 +18,8 @@ PR: #51
 1. feat: add `VITE_DEV_SERVER_URL` to electron
 process env, so that it is easier to use
 
-2. fix(🐞): VITE_DEV_SERVER_HOST cannot be used directly when
-VITE_DEV_SERVER_HOST is a ipv6 address or
+2. fix(🐞): VITE_DEV_SERVER_HOSTNAME cannot be used directly when
+VITE_DEV_SERVER_HOSTNAME is a ipv6 address or
 vite config `server.host` is true
 
 3. fix(🐞): use vite config `mode` as default build

--- a/packages/electron/electron-env.d.ts
+++ b/packages/electron/electron-env.d.ts
@@ -2,7 +2,7 @@
 declare namespace NodeJS {
   interface ProcessEnv {
     NODE_ENV: 'development' | 'production'
-    readonly VITE_DEV_SERVER_HOST: string
+    readonly VITE_DEV_SERVER_HOSTNAME: string
     readonly VITE_DEV_SERVER_PORT: string
     readonly VITE_DEV_SERVER_URL: string
   }

--- a/packages/electron/src/config.ts
+++ b/packages/electron/src/config.ts
@@ -178,7 +178,7 @@ export function resolveEnv(server: ViteDevServer) {
 
   if (isAddressInfo(addressInfo)) {
     const { address, port } = addressInfo
-    const host = resolveHostname(address)
+    const hostname = resolveHostname(address)
 
     const options = server.config.server
     const protocol = options.https ? 'https' : 'http'
@@ -187,8 +187,8 @@ export function resolveEnv(server: ViteDevServer) {
     const path = typeof options.open === 'string' ? options.open : devBase
     const url = path.startsWith('http')
       ? path
-      : `${protocol}://${host}:${port}${path}`
+      : `${protocol}://${hostname}:${port}${path}`
 
-    return { url, host, port }
+    return { url, hostname, port }
   }
 }

--- a/packages/electron/src/serve.ts
+++ b/packages/electron/src/serve.ts
@@ -63,7 +63,7 @@ export async function bootstrap(config: Configuration, server: ViteDevServer) {
   if (env) {
     Object.assign(process.env, {
       VITE_DEV_SERVER_URL: env.url,
-      VITE_DEV_SERVER_HOST: env.host,
+      VITE_DEV_SERVER_HOSTNAME: env.hostname,
       VITE_DEV_SERVER_PORT: env.port,
     })
   }

--- a/playground/usecase-in-main/electron-env.d.ts
+++ b/playground/usecase-in-main/electron-env.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="vite-plugin-electron/electron-env" />

--- a/playground/usecase-in-main/electron/main/index.ts
+++ b/playground/usecase-in-main/electron/main/index.ts
@@ -14,12 +14,15 @@ export const ROOT_PATH = {
 let win: BrowserWindow | null = null
 // Here, you can also use other preload
 const preload = path.join(__dirname, '../preload/index.js')
-// 🚧 Use ['ENV_NAME'] avoid vite:define plugin
-const url = `http://${process.env['VITE_DEV_SERVER_HOST']}:${process.env['VITE_DEV_SERVER_PORT']}`
+const url = process.env.VITE_DEV_SERVER_URL as string
 const indexHtml = path.join(ROOT_PATH.dist, 'index.html')
 
 function createWindow() {
-  win = new BrowserWindow({})
+  win = new BrowserWindow({
+    webPreferences: {
+      preload,
+    },
+  })
 
   if (app.isPackaged) {
     win.loadFile(indexHtml)

--- a/playground/usecase-in-main/tsconfig.json
+++ b/playground/usecase-in-main/tsconfig.json
@@ -16,5 +16,7 @@
     "noImplicitReturns": true,
     "skipLibCheck": true
   },
-  "include": ["src", "electron-env.d.ts", "vite.config.ts"]
+  "types": [
+    "vite-plugin-electron/electron-env"
+  ]
 }

--- a/playground/usecase-in-renderer/electron-env.d.ts
+++ b/playground/usecase-in-renderer/electron-env.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="vite-plugin-electron/electron-env" />

--- a/playground/usecase-in-renderer/electron/main.ts
+++ b/playground/usecase-in-renderer/electron/main.ts
@@ -13,8 +13,7 @@ export const ROOT_PATH = {
 let win: BrowserWindow | null = null
 // Here, you can also use other preload
 const preload = path.join(__dirname, 'preload.js')
-// 🚧 Use ['ENV_NAME'] avoid vite:define plugin
-const url = `http://${process.env['VITE_DEV_SERVER_HOST']}:${process.env['VITE_DEV_SERVER_PORT']}`
+const url = process.env.VITE_DEV_SERVER_URL as string
 const indexHtml = path.join(ROOT_PATH.dist, 'index.html')
 
 function createWindow() {

--- a/playground/usecase-in-renderer/tsconfig.json
+++ b/playground/usecase-in-renderer/tsconfig.json
@@ -14,7 +14,9 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,
-    "skipLibCheck": true
-  },
-  "include": ["src", "electron-env.d.ts", "vite.config.ts"]
+    "skipLibCheck": true,
+    "types": [
+      "vite-plugin-electron/electron-env"
+    ]
+  }
 }


### PR DESCRIPTION
*vite-plugin-electron*

- 715a1cd fix(electron): `VITE_DEV_SERVER_HOSTNAME` instead `VITE_DEV_SERVER_HOST`

*vite-plugin-electron-renderer*
