### PR TITLE
feat: support worker script

### DIFF
--- a/packages/electron/README.md
+++ b/packages/electron/README.md
@@ -82,6 +82,9 @@ export interface Configuration {
      */
     input: InputOption
   }
+  worker?: CommonConfiguration & {
+    input: InputOption
+  }
   /**
    * Support use Node.js API in Electron-Renderer
    * @see https://github.com/electron-vite/vite-plugin-electron/tree/main/packages/electron-renderer

--- a/packages/electron/src/build.ts
+++ b/packages/electron/src/build.ts
@@ -20,6 +20,16 @@ export async function build(config: Configuration, viteConfig: ResolvedConfig) {
     )
   }
 
+  if (config.worker) {
+    const workerRuntime = resolveRuntime('worker', config, viteConfig)
+    await viteBuild(
+      createWithExternal(workerRuntime)(
+        resolveBuildConfig(workerRuntime)
+      )
+    )
+  }
+  
+
   const mainRuntime = resolveRuntime('main', config, viteConfig)
   const ILCG = createWithExternal(mainRuntime)(resolveBuildConfig(mainRuntime))
   if (!ILCG.plugins) ILCG.plugins = []

--- a/packages/electron/src/types.ts
+++ b/packages/electron/src/types.ts
@@ -24,6 +24,9 @@ export interface Configuration {
      */
     input: InputOption
   }
+  worker?: CommonConfiguration & {
+    input: InputOption
+  }
   /**
    * Support use Node.js API in Electron-Renderer
    * @see https://github.com/electron-vite/vite-plugin-electron/tree/main/packages/electron-renderer

--- a/playground/usecase-in-main/electron/main/index.ts
+++ b/playground/usecase-in-main/electron/main/index.ts
@@ -1,6 +1,7 @@
 import path from 'path'
-import { app, BrowserWindow } from 'electron'
+import { app, BrowserWindow, ipcMain } from 'electron'
 import './samples'
+import { Worker } from 'node:worker_threads'
 
 process.env['ELECTRON_DISABLE_SECURITY_WARNINGS'] = 'true'
 
@@ -31,4 +32,19 @@ function createWindow() {
   }
 }
 
-app.whenReady().then(createWindow)
+app.whenReady().then(() => {
+  ipcMain.handle('sigma', (e, factor: number) => {
+    return new Promise((resolve, reject) => {
+      const worker = new Worker(path.join(__dirname, '../worker/task1.js'))
+      worker.on('message', result => {
+        resolve(result)
+      })
+      worker.on('error', error => {
+        reject(error)
+      })
+      worker.postMessage(factor)
+    })
+  })
+
+  createWindow()
+})

--- a/playground/usecase-in-main/electron/preload/index.ts
+++ b/playground/usecase-in-main/electron/preload/index.ts
@@ -1,3 +1,4 @@
+import { contextBridge, ipcRenderer } from 'electron'
 function domReady(condition: DocumentReadyState[] = ['complete', 'interactive']) {
   return new Promise(resolve => {
     if (condition.includes(document.readyState)) {
@@ -88,5 +89,11 @@ domReady().then(appendLoading)
 window.onmessage = ev => {
   ev.data.payload === 'removeLoading' && removeLoading()
 }
+
+console.log('versions', process.versions)
+
+contextBridge.exposeInMainWorld('electronApi', {
+  sigma: (num: number) => ipcRenderer.invoke('sigma', num)
+})
 
 setTimeout(removeLoading, 4999)

--- a/playground/usecase-in-main/electron/worker/lib/util.ts
+++ b/playground/usecase-in-main/electron/worker/lib/util.ts
@@ -1,0 +1,13 @@
+import { join } from 'node:path'
+
+export function getPath(relative: string) {
+  return join(__dirname, relative)
+}
+
+export function factorial(factor: number) {
+  let result = 1
+  for (let i = 1; i <= factor; i++) {
+    result += i
+  }
+  return result
+}

--- a/playground/usecase-in-main/electron/worker/task1.ts
+++ b/playground/usecase-in-main/electron/worker/task1.ts
@@ -1,0 +1,8 @@
+import { factorial } from './lib/util'
+import { parentPort } from 'node:worker_threads'
+
+parentPort?.on('message', mes => {
+  const result = factorial(mes)
+  parentPort?.postMessage(result)
+})
+

--- a/playground/usecase-in-main/global.d.ts
+++ b/playground/usecase-in-main/global.d.ts
@@ -1,0 +1,9 @@
+declare global {
+  interface Window {
+    electronApi: {
+      sigma: (fac: number) => Promise<number>
+    }
+  }
+}
+
+export {}

--- a/playground/usecase-in-main/src/factorial.ts
+++ b/playground/usecase-in-main/src/factorial.ts
@@ -1,0 +1,18 @@
+export function setupFactorial(element: HTMLButtonElement) {
+  let calcing = false
+  const factor = 5e9
+  element.innerHTML = `sigma 5e9`
+  const calc = () => {
+    if (!calcing) {
+      calcing = true
+      element.innerHTML = `calculating ...`
+      const start = Date.now()
+      window.electronApi.sigma(factor).then(result => {
+        element.innerHTML = `sum is ${result}, cost ${((Date.now() - start) / 1000).toFixed(2)}s`
+        calcing = false
+      })
+    }
+
+  }
+  element.addEventListener('click', () => calc())
+}

--- a/playground/usecase-in-main/src/main.ts
+++ b/playground/usecase-in-main/src/main.ts
@@ -2,6 +2,7 @@ import './style.css'
 import viteLogo from '/vite.svg'
 import typescriptLogo from './typescript.svg'
 import { setupCounter } from './counter'
+import { setupFactorial } from './factorial'
 
 document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
   <div>
@@ -14,6 +15,7 @@ document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
     <h1>Vite + TypeScript</h1>
     <div class="card">
       <button id="counter" type="button"></button>
+      <button id="factorial" type="button">1000 of factorial</button>
     </div>
     <p class="read-the-docs">
       Click on the Vite and TypeScript logos to learn more
@@ -22,5 +24,6 @@ document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
 `
 
 setupCounter(document.querySelector<HTMLButtonElement>('#counter')!)
+setupFactorial(document.querySelector<HTMLButtonElement>('#factorial')!)
 
 postMessage({ payload: 'removeLoading' }, '*')

--- a/playground/usecase-in-main/vite.config.ts
+++ b/playground/usecase-in-main/vite.config.ts
@@ -47,6 +47,20 @@ export default defineConfig({
           },
         },
       },
+      worker: {
+        input: {
+          // You can configure multiple worker here
+          task1: path.join(__dirname, 'electron/worker/task1.ts'),
+        },
+        vite: {
+          build: {
+            // For debug
+            sourcemap: 'inline',
+            outDir: 'dist/electron/worker',
+            minify: false,
+          },
+        },
+      },
     }),
   ],
   build: {


### PR DESCRIPTION
I want to use`node:worker_threads.Worker` for the heavy compute cost in the main process and something like hmr of the worker script files.
similar to the main script, it will restart the electron app when developing the worker script files.

changes:
1. add additional option of `worker`, similar to the preload option.
```typescript
export interface Configuration {
  main: CommonConfiguration & {
    /**
     * Shortcut of `build.lib.entry`
     */
    entry: LibraryOptions['entry']
  }
  preload?: CommonConfiguration & {
    /**
     * Shortcut of `build.rollupOptions.input`
     */
    input: InputOption
  }
  worker?: CommonConfiguration & {
    input: InputOption
  }
  /**
   * Support use Node.js API in Electron-Renderer
   * @see https://github.com/electron-vite/vite-plugin-electron/tree/main/packages/electron-renderer
   */
  renderer?: Options
}
```
2. add example of how to use this.(playground/usecase-in-main)