### PR TITLE
V0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.10.2 (2022-10-24)
+
+1. Remove Vite `3.2.0` | #90
+2. ad9bb3c refactor(electron-renderer)!: remove `options.resolve()`, use 'lib-esm' for resolve Node.js modules and `electron` | vite-plugin-electron-renderer
+3. b500039 feat(electron-renderer): support `optimizeDeps` for Electron-Renderer 🚀
+4. f28e66b faet(outDir)!: `dist/electron` -> `dist/electron` | vite-plugin-electron
+
 ## 0.10.1 (2022-10-12)
 
 - 59a24df fix(electron-renderer): use `createRequire()` instead of `import()` 🐞

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,1 @@
+*/dist-electron

--- a/examples/custom-start-electron-app/package.json
+++ b/examples/custom-start-electron-app/package.json
@@ -20,6 +20,6 @@
     "electron-builder": "^23.1.0",
     "typescript": "^4.7.4",
     "vite-plugin-electron": "workspace:*",
-    "vite": "^3.2.0-beta.0"
+    "vite": "^3.1.8"
   }
 }

--- a/examples/custom-start-electron-app/vite.config.ts
+++ b/examples/custom-start-electron-app/vite.config.ts
@@ -3,17 +3,15 @@ import { defineConfig } from 'vite'
 import electron from 'vite-plugin-electron'
 
 fs.rmSync('dist', { recursive: true, force: true })
-const cmds = process.argv.slice(2)
-const isdev = !cmds.length || cmds.includes('dev') || cmds.includes('serve')
 
 export default defineConfig({
   plugins: [
     electron({
       entry: 'electron/main.ts',
-      onstart: isdev ? startup => {
+      onstart: options => {
         /** Start Electron App */
-        startup(['.', '--no-sandbox'])
-      } : undefined,
+        options.startup(['.', '--no-sandbox'])
+      },
     }),
   ],
 })

--- a/examples/nodeIntegration/electron-builder.json5
+++ b/examples/nodeIntegration/electron-builder.json5
@@ -10,7 +10,10 @@
     output: "release/${version}",
     buildResources: "electron/resources",
   },
-  files: ["dist"],
+  files: [
+    "dist",
+    "dist-electron"
+  ],
   win: {
     target: [
       {

--- a/examples/nodeIntegration/electron/main.ts
+++ b/examples/nodeIntegration/electron/main.ts
@@ -16,7 +16,7 @@ app.whenReady().then(() => {
   })
 
   if (app.isPackaged) {
-    win.loadFile(path.join(__dirname, '../index.html'))
+    win.loadFile(path.join(__dirname, '../dist/index.html'))
   } else {
     win.loadURL(process.env.VITE_DEV_SERVER_URL)
     win.webContents.openDevTools()

--- a/examples/nodeIntegration/package.json
+++ b/examples/nodeIntegration/package.json
@@ -29,6 +29,6 @@
     "vite-plugin-electron": "workspace:*",
     "vite-plugin-electron-renderer": "workspace:*",
     "vite-plugin-esmodule": "^1.4.1",
-    "vite": "^3.2.0-beta.0"
+    "vite": "^3.1.8"
   }
 }

--- a/examples/nodeIntegration/package.json
+++ b/examples/nodeIntegration/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite-plugin-electron-node-integration",
   "version": "0.0.0",
-  "main": "dist/electron/main.js",
+  "main": "dist-electron/main.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/electron-vite/vite-plugin-electron.git",
@@ -26,9 +26,8 @@
     "execa": "^6.1.0",
     "got": "^12.1.0",
     "node-fetch": "^3.2.8",
+    "vite": "^3.1.8",
     "vite-plugin-electron": "workspace:*",
-    "vite-plugin-electron-renderer": "workspace:*",
-    "vite-plugin-esmodule": "^1.4.1",
-    "vite": "^3.1.8"
+    "vite-plugin-electron-renderer": "workspace:*"
   }
 }

--- a/examples/nodeIntegration/vite.config.ts
+++ b/examples/nodeIntegration/vite.config.ts
@@ -2,7 +2,6 @@ import fs from 'fs'
 import { defineConfig } from 'vite'
 import electron from 'vite-plugin-electron'
 import renderer from 'vite-plugin-electron-renderer'
-import esmodule from 'vite-plugin-esmodule'
 import pkg from './package.json'
 
 fs.rmSync('dist', { recursive: true, force: true })
@@ -15,13 +14,17 @@ export default defineConfig({
     renderer({
       // Enables use of Node.js API in the Renderer-process
       nodeIntegration: true,
-      // Explicitly specify external modules
-      resolve: () => ['serialport', 'sqlite3'],
+      // Like Vite's pre bundling
+      optimizeDeps: {
+        include: [
+          'serialport',     // cjs(C++)
+          'electron-store', // cjs
+          'execa',          // esm
+          'got',            // esm
+          'node-fetch',     // esm
+        ],
+      },
     }),
-    // If an npm package is a pure ESM format package, 
-    // and the packages it depends on are also in ESM format, 
-    // then put it in `optimizeDeps.exclude` and it will work normally.
-    esmodule(['execa', 'got', 'node-fetch']),
   ],
   build: {
     minify: false,
@@ -30,6 +33,9 @@ export default defineConfig({
     },
   },
   optimizeDeps: {
+    // If an npm package is a pure ESM format package, 
+    // and the packages it depends on are also in ESM format, 
+    // then put it in `optimizeDeps.exclude` and it will work normally.
     // exclude: ['only-support-pure-esmodule-package'],
   },
 })

--- a/examples/quick-start/electron/preload.ts
+++ b/examples/quick-start/electron/preload.ts
@@ -15,12 +15,12 @@ function domReady(condition: DocumentReadyState[] = ['complete', 'interactive'])
 const safeDOM = {
   append(parent: HTMLElement, child: HTMLElement) {
     if (!Array.from(parent.children).find(e => e === child)) {
-      return parent.appendChild(child)
+      parent.appendChild(child)
     }
   },
   remove(parent: HTMLElement, child: HTMLElement) {
     if (Array.from(parent.children).find(e => e === child)) {
-      return parent.removeChild(child)
+      parent.removeChild(child)
     }
   },
 }

--- a/examples/quick-start/package.json
+++ b/examples/quick-start/package.json
@@ -20,6 +20,6 @@
     "electron-builder": "^23.1.0",
     "typescript": "^4.7.4",
     "vite-plugin-electron": "workspace:*",
-    "vite": "^3.2.0-beta.0"
+    "vite": "^3.1.8"
   }
 }

--- a/examples/quick-start/vite.config.ts
+++ b/examples/quick-start/vite.config.ts
@@ -6,11 +6,14 @@ fs.rmSync('dist', { recursive: true, force: true })
 
 export default defineConfig({
   plugins: [
-    electron({
-      entry: [
-        'electron/main.ts',
-        'electron/preload.ts',
-      ],
-    }),
+    electron([
+      { entry: 'electron/main.ts' },
+      {
+        entry: 'electron/preload.ts',
+        onstart(options) {
+          options.reload()
+        },
+      },
+    ]),
   ],
 })

--- a/examples/worker/package.json
+++ b/examples/worker/package.json
@@ -21,6 +21,6 @@
     "typescript": "^4.7.4",
     "vite-plugin-electron": "workspace:*",
     "vite-plugin-electron-renderer": "workspace:*",
-    "vite": "^3.2.0-beta.0"
+    "vite": "^3.2.0-beta.3"
   }
 }

--- a/examples/worker/vite.config.ts
+++ b/examples/worker/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
   },
   plugins: [
     electron({
+      // Multiple entry needed Vite >= 3.2.0
       entry: [
         'electron/main.ts',
         'electron/worker.ts',

--- a/packages/electron-renderer/package.json
+++ b/packages/electron-renderer/package.json
@@ -27,7 +27,9 @@
     "types": "tsc --emitDeclarationOnly",
     "prepublishOnly": "npm run build"
   },
-  "dependencies": {},
+  "dependencies": {
+    "lib-esm": "~0.3.0"
+  },
   "devDependencies": {
     "esbuild": "^0.15.10",
     "rollup": "~2.78.0",

--- a/packages/electron-renderer/package.json
+++ b/packages/electron-renderer/package.json
@@ -30,9 +30,10 @@
   "dependencies": {},
   "devDependencies": {
     "esbuild": "^0.15.10",
+    "rollup": "~2.78.0",
     "typescript": "^4.7.4",
-    "vite": "^3.2.0-beta.0",
-    "rollup": "^2.77.0"
+    "vite": "^3.1.8",
+    "vite-plugin-utils": "^0.3.6"
   },
   "files": [
     "plugins",

--- a/packages/electron-renderer/package.json
+++ b/packages/electron-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-electron-renderer",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Support use Node.js API in Electron-Renderer",
   "main": "plugins/index.mjs",
   "types": "plugins",

--- a/packages/electron-renderer/resolve.md
+++ b/packages/electron-renderer/resolve.md
@@ -1,0 +1,232 @@
+# vite-plugin-electron-renderer
+
+Support use Node.js API in Electron-Renderer
+
+[![NPM version](https://img.shields.io/npm/v/vite-plugin-electron-renderer.svg)](https://npmjs.org/package/vite-plugin-electron-renderer)
+[![NPM Downloads](https://img.shields.io/npm/dm/vite-plugin-electron-renderer.svg)](https://npmjs.org/package/vite-plugin-electron-renderer)
+
+English | [简体中文](https://github.com/electron-vite/vite-plugin-electron/blob/main/packages/electron-renderer/README.zh-CN.md)
+
+## Install
+
+```sh
+npm i vite-plugin-electron-renderer -D
+```
+
+## Examples
+
+- [nodeIntegration](https://github.com/caoxiemeihao/vite-plugin-electron/tree/main/examples/nodeIntegration)
+- [worker](https://github.com/caoxiemeihao/vite-plugin-electron/tree/main/examples/worker)
+
+## Usage
+
+vite.config.ts
+
+```js
+import renderer from 'vite-plugin-electron-renderer'
+
+export default {
+  plugins: [
+    renderer(/* options */),
+  ],
+}
+```
+
+renderer.js
+
+```ts
+import { readFile } from 'fs'
+import { ipcRenderer } from 'electron'
+
+readFile(/* something code... */)
+ipcRenderer.on('event-name', () => {/* something code... */})
+```
+
+API *(Define)*
+
+`renderer(options: RendererOptions)`
+
+```ts
+export interface RendererOptions {
+  /**
+   * Explicitly include/exclude some CJS modules  
+   * `modules` includes `dependencies` of package.json  
+   */
+  resolve?: (modules: string[]) => string[] | void
+  /**
+   * Whether node integration is enabled. Default is `false`.
+   */
+  nodeIntegration?: boolean
+}
+```
+
+## Worker
+
+vite.config.ts
+
+```js
+import { worker } from 'vite-plugin-electron-renderer'
+
+export default {
+  worker: {
+    plugins: [
+      worker(/* options */),
+    ],
+  },
+}
+```
+
+API *(Define)*
+
+`renderer(options: WorkerOptions)`
+
+```ts
+export interface WorkerOptions {
+  /**
+   * Explicitly include/exclude some CJS modules  
+   * `modules` includes `dependencies` of package.json  
+   */
+  resolve?: (modules: string[]) => string[] | void
+  /**
+   * Whether node integration is enabled in web workers. Default is `false`. More
+   * about this can be found in Multithreading.
+   */
+  nodeIntegrationInWorker?: boolean
+}
+```
+
+## `dependencies` vs `devDependencies`
+
+> In general, Vite may not correctly build Node.js packages, especially Node.js C/C++ native modules, but Vite can load them as external packages. **Unless you know how to properly build them with Vite.**
+
+<table>
+  <thead>
+    <th>Classify</th>
+    <th>e.g.</th>
+    <th>dependencies</th>
+    <th>devDependencies</th>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Node.js C/C++ native modules</td>
+      <td>serialport, sqlite3</td>
+      <td>✅</td>
+      <td>❌</td>
+    </tr>
+    <tr>
+      <td>Node.js CJS packages</td>
+      <td>electron-store</td>
+      <td>✅</td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td>Node.js ESM packages</td>
+      <td>execa, got, node-fetch</td>
+      <td>✅</td>
+      <td>✅ (Recommend)</td>
+    </tr>
+    <tr>
+      <td>Web packages</td>
+      <td>Vue, React</td>
+      <td>✅</td>
+      <td>✅ (Recommend)</td>
+    </tr>
+  </tbody>
+</table>
+
+First, put the Node.js(CJS) packages into `dependencies`.
+
+Second, you need to explicitly specify which packages are Node.js(CJS) packages for `vite-plugin-electron-renderer` by `options.resolve()`. This way they will be treated as `external` modules and loaded correctly. Thereby avoiding the problems caused by the Pre-Bundling of Vite.
+
+It's essentially works principle is to generate a virtual module in ESM format by `load-hook` during `vite serve` to ensure that it can work normally. It's inserted into `rollupOptions.external` during `vite build` time.
+
+#### Load Node.js C/C++ native modules
+
+```js
+renderer({
+  resolve() {
+    // explicitly specify which packages are Node.js(CJS) packages
+    return [
+      // C/C++ native modules
+      'serialport',
+      'sqlite3',
+    ]
+  }
+})
+```
+
+#### Load Node.js CJS packages/builtin-modules/electron (Schematic)
+
+###### Electron-Renderer(vite build)
+
+```js
+import { ipcRenderer } from 'electron'
+↓
+const { ipcRenderer } = require('electron')
+```
+
+###### Electron-Renderer(vite serve)
+
+```
+┏————————————————————————————————————————┓                    ┏—————————————————┓
+│ import { ipcRenderer } from 'electron' │                    │ Vite dev server │
+┗————————————————————————————————————————┛                    ┗—————————————————┛
+                   │                                                   │
+                   │ 1. HTTP(Request): electron module                 │
+                   │ ————————————————————————————————————————————————> │
+                   │                                                   │
+                   │                                                   │
+                   │ 2. Intercept in load-hook(Plugin)                 │
+                   │ 3. Generate a virtual ESM module(electron)        │
+                   │    ↓                                              │
+                   │    const { ipcRenderer } = require('electron')    │
+                   │    export { ipcRenderer }                         │
+                   │                                                   │
+                   │                                                   │
+                   │ 4. HTTP(Response): electron module                │
+                   │ <———————————————————————————————————————————————— │
+                   │                                                   │
+┏————————————————————————————————————————┓                    ┏—————————————————┓
+│ import { ipcRenderer } from 'electron' │                    │ Vite dev server │
+┗————————————————————————————————————————┛                    ┗—————————————————┛
+```
+
+#### Node.js ESM packages
+
+###### The first way
+
+In general, Node.js ESM packages only need to be converted if they are used in Electron-Renderer. But not in Electron-Main.
+
+1. Install [vite-plugin-esmodule](https://github.com/vite-plugin/vite-plugin-esmodule) to load ESM packages
+2. It is recommended to put the ESM packages in the `devDependencies`
+
+> [See an explanation of it](https://github.com/electron-vite/vite-plugin-electron/blob/b4d616a8d0e25f01f5e589b4a6ef69220866ce5d/examples/nodeIntegration/vite.config.ts#L21-L24)
+
+###### The second way
+
+```diff
+export default {
++ optimizeDeps: {
++   exclude: ['only-support-pure-esmodule-package']
++ }
+}
+```
+
+#### Why is it recommended to put properly buildable packages in `devDependencies`?
+
+Doing so will reduce the size of the packaged APP by [electron-builder](https://github.com/electron-userland/electron-builder).
+
+## How to work
+
+The plugin is just the encapsulation of the built-in plugins of [electron-vite-boilerplate/packages/renderer/plugins](https://github.com/electron-vite/electron-vite-boilerplate/tree/main/packages/renderer/plugins).
+
+## Config presets (Opinionated)
+
+If you do not configure the following options, the plugin will modify their default values
+
+- `base = './'`
+- `build.emptyOutDir = false`
+- `build.cssCodeSplit = false` (*TODO*)
+- `build.rollupOptions.output.format = 'cjs'` (nodeIntegration: true)
+- `resolve.conditions = ['node']`
+- `optimizeDeps.exclude = ['electron']` - always

--- a/packages/electron-renderer/resolve.zh-CN.md
+++ b/packages/electron-renderer/resolve.zh-CN.md
@@ -1,0 +1,110 @@
+# vite-plugin-electron-renderer
+
+[English](https://github.com/electron-vite/vite-plugin-electron/tree/main/packages/electron-renderer#readme) | 简体中文
+
+## `dependencies` 与 `devDependencies`
+
+> 通常的，Vite 可能不能正确的构建 Node.js 包，尤其是 Node.js C/C++ 原生模块，但是 Vite 可以将它们以外部包(`external`)的形式加载它们。**除非你知道如何用 Vite 正确的构建它们 -- 鲁迅**
+
+<table>
+  <thead>
+    <th>分类</th>
+    <th>🌰</th>
+    <th>dependencies</th>
+    <th>devDependencies</th>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Node.js C/C++ 原生模块</td>
+      <td>serialport, sqlite3</td>
+      <td>✅</td>
+      <td>❌</td>
+    </tr>
+    <tr>
+      <td>Node.js CJS 包</td>
+      <td>electron-store</td>
+      <td>✅</td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td>Node.js ESM 包</td>
+      <td>execa, got, node-fetch</td>
+      <td>✅</td>
+      <td>✅ (推荐)</td>
+    </tr>
+    <tr>
+      <td>Web 包</td>
+      <td>Vue, React</td>
+      <td>✅</td>
+      <td>✅ (推荐)</td>
+    </tr>
+  </tbody>
+</table>
+
+首先将 Node.js(CJS) 包放到 `dependencies` 中。
+
+其次需要通过 `options.resolve()` 显式的告诉 `vite-plugin-electron-renderer` 哪些包是 Node.js(CJS) 包。这样它们将会被视为 `external` 模块并可以正确的加载。从而避开 Vite 的预构建带来的问题。
+
+其背后的运行原理是在 `vite serve` 期间会通过 `load-hook` 生成一个 ESM 格式的虚拟模块，以保障其能够正常工作。在 `vite build` 期间会将其插入到 `rollupOptions.external` 中。
+
+#### Node.js C/C++ 原生模块
+
+```js
+renderer({
+  resolve() {
+    // 显式的告诉 `vite-plugin-electron-renderer` 下面的包是 Node.js(CJS) 模块
+    return [
+      // C/C++ 原生模块
+      'serialport',
+      'sqlite3',
+    ]
+  }
+})
+```
+
+#### 加载 Node.js CJS 包/内置模块/electron (示意图)
+
+###### Electron-Renderer(vite build)
+
+```js
+import { ipcRenderer } from 'electron'
+↓
+const { ipcRenderer } = require('electron')
+```
+
+###### Electron-Renderer(vite serve)
+
+```
+┏————————————————————————————————————————┓                    ┏—————————————————┓
+│ import { ipcRenderer } from 'electron' │                    │ Vite dev server │
+┗————————————————————————————————————————┛                    ┗—————————————————┛
+                   │                                                   │
+                   │ 1. HTTP(Request): electron module                 │
+                   │ ————————————————————————————————————————————————> │
+                   │                                                   │
+                   │                                                   │
+                   │ 2. Intercept in load-hook(Plugin)                 │
+                   │ 3. Generate a virtual ESM module(electron)        │
+                   │    ↓                                              │
+                   │    const { ipcRenderer } = require('electron')    │
+                   │    export { ipcRenderer }                         │
+                   │                                                   │
+                   │                                                   │
+                   │ 4. HTTP(Response): electron module                │
+                   │ <———————————————————————————————————————————————— │
+                   │                                                   │
+┏————————————————————————————————————————┓                    ┏—————————————————┓
+│ import { ipcRenderer } from 'electron' │                    │ Vite dev server │
+┗————————————————————————————————————————┛                    ┗—————————————————┛
+```
+
+#### Node.js ESM 包
+
+通常的，只有在 Electron-Renderer 中使用的情况下才需要转换 Node.js ESM 模块，而在 Electron-Main 中使用则不必转换。
+
+1. 安装 [vite-plugin-esmodule](https://github.com/vite-plugin/vite-plugin-esmodule) 插件加载 ESM 包。
+2. 推荐将 ESM 包辅导会 `devDependencies` 中。
+
+#### 为什么推荐将可以正确构建的包放到 `devDependencies` 中？
+
+这样做会减小 [electron-builder](https://github.com/electron-userland/electron-builder) 打包后的应用体积。

--- a/packages/electron-renderer/src/build-config.ts
+++ b/packages/electron-renderer/src/build-config.ts
@@ -13,15 +13,8 @@ export default function buildConfig(): Plugin {
       // TODO: init `config.build.target`
       // https://github.com/vitejs/vite/pull/8843
 
-      // ensure that static resources are loaded normally
-      // TODO: Automatic splicing `build.assetsDir`
-      // config.build.assetsDir ??= ''
-
       // https://github.com/electron-vite/electron-vite-vue/issues/107
       config.build.cssCodeSplit ??= false
-
-      // prevent accidental clearing of `dist/electron/main`, `dist/electron/preload`
-      config.build.emptyOutDir ??= false
     },
   }
 }

--- a/packages/electron-renderer/src/index.ts
+++ b/packages/electron-renderer/src/index.ts
@@ -13,6 +13,7 @@ import {
 export default function renderer(
   options: Omit<UseNodeJsOptions, 'nodeIntegrationInWorker'> & {
     /**
+     * If the npm-package you are using is a Node.js package, then you need to Pre Bundling it.
      * @see https://vitejs.dev/guide/dep-pre-bundling.html
      */
     optimizeDeps?: DepOptimizationConfig

--- a/packages/electron-renderer/src/index.ts
+++ b/packages/electron-renderer/src/index.ts
@@ -5,14 +5,24 @@ import {
   type UseNodeJsOptions,
   default as useNodeJs,
 } from './use-node.js'
+import {
+  type DepOptimizationConfig,
+  default as optimizer,
+} from './optimizer'
 
 export default function renderer(
-  options: Omit<UseNodeJsOptions, 'nodeIntegrationInWorker'> = {}
+  options: Omit<UseNodeJsOptions, 'nodeIntegrationInWorker'> & {
+    /**
+     * @see https://vitejs.dev/guide/dep-pre-bundling.html
+     */
+    optimizeDeps?: DepOptimizationConfig
+  } = {}
 ): PluginOption {
   return [
     buildConfig(),
     options.nodeIntegration && cjsShim(),
     useNodeJs(options),
+    options.optimizeDeps && optimizer(options.optimizeDeps),
   ]
 }
 

--- a/packages/electron-renderer/src/optimizer.ts
+++ b/packages/electron-renderer/src/optimizer.ts
@@ -1,0 +1,225 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { createRequire, builtinModules } from 'node:module'
+import type { Alias, Plugin, UserConfig } from 'vite'
+import esbuild from 'esbuild'
+import libEsm from 'lib-esm'
+
+export type DepOptimizationConfig = {
+  include?: (string | {
+    name: string
+    /**
+     * Explicitly specify the module type
+     */
+    type?: "commonjs" | "module"
+  })[]
+  buildOptions?: import('esbuild').BuildOptions
+  // TODO: consider support webpack 🤔
+  // webpack?: import('webpack').Configuration
+}
+
+const cjs_require = createRequire(import.meta.url)
+let root: string
+let node_modules_path: string
+const CACHE_DIR = '.vite-electron-renderer'
+
+export default function optimizer(options: DepOptimizationConfig): Plugin {
+  return {
+    name: 'vite-plugin-electron-renderer:optimizer',
+    async config(config) {
+      root = config.root ? path.resolve(config.root) : process.cwd()
+      node_modules_path = node_modules(root)
+
+      fs.rmSync(path.join(node_modules_path, CACHE_DIR), { recursive: true, force: true })
+      const { include, buildOptions } = options
+      if (!include?.length) return
+
+      const deps: {
+        esm?: string
+        cjs?: string
+        filename?: string
+      }[] = []
+      const aliases: Alias[] = []
+      const optimizeDepsExclude = []
+
+      for (const item of include) {
+        let name: string
+        let type: string | undefined
+        if (typeof item === 'string') {
+          name = item
+        } else {
+          name = item.name
+          type = item.type
+        }
+        if (type === 'module') {
+          deps.push({ esm: name })
+          continue
+        }
+        if (type === 'commonjs') {
+          deps.push({ cjs: name })
+          continue
+        }
+        const pkg = cjs_require(path.join(node_modules_path, name, 'package.json'))
+        if (pkg) {
+          // bare module
+          if (pkg.type === 'module') {
+            deps.push({ esm: name })
+            continue
+          }
+          deps.push({ cjs: name })
+          continue
+        }
+        const tmp = path.join(node_modules_path, name)
+        try {
+          // dirname or filename
+          // `foo/bar` or `foo/bar/index.js`
+          const filename = cjs_require.resolve(tmp)
+          if (path.extname(filename) === '.mjs') {
+            deps.push({ esm: name, filename })
+            continue
+          }
+          deps.push({ cjs: name, filename })
+        } catch (error) {
+          console.log('Can not resolve path:', tmp)
+        }
+      }
+
+      for (const dep of deps) {
+        if (!dep.filename) {
+          const module = (dep.cjs || dep.esm) as string
+          try {
+            dep.filename = cjs_require.resolve(module)
+          } catch (error) {
+            console.log('Can not resolve module:', module)
+          }
+        }
+        if (!dep.filename) {
+          continue
+        }
+
+        if (dep.cjs) {
+          cjsBundling({
+            name: dep.cjs,
+            require: dep.cjs,
+            requireId: dep.filename,
+          })
+        } else if (dep.esm) {
+          esmBundling({
+            name: dep.esm,
+            entry: dep.filename,
+            buildOptions,
+          })
+        }
+
+        const name = dep.cjs || dep.esm
+        if (name) {
+          optimizeDepsExclude.push(name)
+          const { destname } = dest(name)
+          aliases.push({ find: name, replacement: destname })
+        }
+      }
+
+      modifyOptimizeDeps(config, optimizeDepsExclude)
+      modifyAlias(config, aliases)
+    },
+  }
+}
+
+function cjsBundling(args: {
+  name: string
+  require: string
+  requireId: string
+}) {
+  const { name, require, requireId } = args
+  const { exports } = libEsm({ exports: Object.keys(cjs_require(requireId)) })
+  const code = `const _M_ = require("${require}");\n${exports}`
+  writeFile({ name, code })
+}
+
+async function esmBundling(args: {
+  name: string,
+  entry: string,
+  buildOptions?: esbuild.BuildOptions,
+}) {
+  const { name, entry, buildOptions } = args
+  const { name_cjs, destname_cjs } = dest(name)
+  return esbuild.build({
+    entryPoints: [entry],
+    outfile: destname_cjs,
+    target: 'node14',
+    format: 'cjs',
+    bundle: true,
+    external: [
+      ...builtinModules,
+      ...builtinModules.map(mod => `node:${mod}`),
+    ],
+    ...buildOptions,
+  }).then(result => {
+    if (!result.errors.length) {
+      cjsBundling({
+        name,
+        require: `${CACHE_DIR}/${name}/${name_cjs}`,
+        requireId: destname_cjs,
+      })
+    }
+    return result
+  })
+}
+
+function writeFile(args: {
+  name: string
+  code: string
+}) {
+  const { name, code } = args
+  const { destpath, destname } = dest(name)
+  !fs.existsSync(destpath) && fs.mkdirSync(destpath, { recursive: true })
+  fs.writeFileSync(destname, code)
+  console.log('Pre-bundling:', name)
+}
+
+function dest(name: string) {
+  const destpath = path.join(node_modules_path, CACHE_DIR, name)
+  const name_js = 'index.js'
+  const name_cjs = 'index.cjs'
+  !fs.existsSync(destpath) && fs.mkdirSync(destpath, { recursive: true })
+  return {
+    destpath,
+    name_js,
+    name_cjs,
+    destname: path.join(destpath, name_js),
+    destname_cjs: path.join(destpath, name_cjs),
+  }
+}
+
+function modifyOptimizeDeps(config: UserConfig, exclude: string[]) {
+  config.optimizeDeps ??= {}
+  config.optimizeDeps.exclude ??= []
+  config.optimizeDeps.exclude.push(...exclude)
+}
+
+function modifyAlias(config: UserConfig, aliases: Alias[]) {
+  config.resolve ??= {}
+  config.resolve.alias ??= []
+  if (Object.prototype.toString.call(config.resolve.alias) === '[object Object]') {
+    config.resolve.alias = Object
+      .entries(config.resolve.alias)
+      .reduce<Alias[]>((memo, [find, replacement]) => memo.concat({ find, replacement }), [])
+  }
+  (config.resolve.alias as Alias[]).push(...aliases)
+}
+
+function node_modules(root: string, count = 0): string {
+  if (node_modules.p) {
+    return node_modules.p
+  }
+  const p = path.join(root, 'node_modules')
+  if (fs.existsSync(p)) {
+    return node_modules.p = p
+  }
+  if (count >= 19) {
+    throw new Error('Can not found node_modules directory.')
+  }
+  return node_modules(path.join(root, '..'), count + 1)
+}
+// For ts-check
+node_modules.p = ''

--- a/packages/electron-renderer/src/optimizer.ts
+++ b/packages/electron-renderer/src/optimizer.ts
@@ -26,6 +26,8 @@ const CACHE_DIR = '.vite-electron-renderer'
 export default function optimizer(options: DepOptimizationConfig): Plugin {
   return {
     name: 'vite-plugin-electron-renderer:optimizer',
+    // At "build" phase, Node.js npm-package will be resolve by './use-node.js.ts'
+    apply: 'serve',
     async config(config) {
       root = config.root ? path.resolve(config.root) : process.cwd()
       node_modules_path = node_modules(root)

--- a/packages/electron-renderer/src/use-node.js.ts
+++ b/packages/electron-renderer/src/use-node.js.ts
@@ -1,6 +1,6 @@
-import fs from 'fs'
-import path from 'path'
-import { builtinModules, createRequire } from 'module'
+import fs from 'node:fs'
+import path from 'node:path'
+import { builtinModules, createRequire } from 'node:module'
 import type { ExternalOption, RollupOptions } from 'rollup'
 import {
   type Plugin,

--- a/packages/electron-renderer/src/use-node.js.ts
+++ b/packages/electron-renderer/src/use-node.js.ts
@@ -7,13 +7,9 @@ import {
   type ConfigEnv,
   normalizePath,
 } from 'vite'
+import libEsm from 'lib-esm'
 
 export interface UseNodeJsOptions {
-  /**
-   * Explicitly include/exclude some CJS modules  
-   * `modules` includes `dependencies` of package.json  
-   */
-  resolve?: (dependencies: string[]) => string[] | void
   /**
    * Whether node integration is enabled. Default is `false`.
    */
@@ -24,74 +20,6 @@ export interface UseNodeJsOptions {
    */
   nodeIntegrationInWorker?: boolean
 }
-
-// https://www.w3schools.com/js/js_reserved.asp
-const keywords = [
-  'abstract',
-  'arguments',
-  'await',
-  'boolean',
-  'break',
-  'byte',
-  'case',
-  'catch',
-  'char',
-  'class',
-  'const',
-  'continue',
-  'debugger',
-  'default',
-  'delete',
-  'do',
-  'double',
-  'else',
-  'enum',
-  'eval',
-  'export',
-  'extends',
-  'false',
-  'final',
-  'finally',
-  'float',
-  'for',
-  'function',
-  'goto',
-  'if',
-  'implements',
-  'import',
-  'in',
-  'instanceof',
-  'int',
-  'interface',
-  'let',
-  'long',
-  'native',
-  'new',
-  'null',
-  'package',
-  'private',
-  'protected',
-  'public',
-  'return',
-  'short',
-  'static',
-  'super',
-  'switch',
-  'synchronized',
-  'this',
-  'throw',
-  'throws',
-  'transient',
-  'true',
-  'try',
-  'typeof',
-  'var',
-  'void',
-  'volatile',
-  'while',
-  'with',
-  'yield',
-]
 
 const electron = `
 /**
@@ -190,12 +118,16 @@ export default function useNodeJs(options: UseNodeJsOptions = {}): Plugin[] {
       // Because `dependencies(NodeJs_pkgs)` may contain Web packages. e.g. `vue`, `react`.
       // Opinionated treat Web packages as external modules, which will cause errors.
       let NodeJs_pkgs: string[] = []
+      /**
+       * 2022-10-18 remove (v0.10.2)
+       * This option is a bit confusing. Consider using `vite-plugin-resolve` instead. 🤔
       if (options.resolve) {
         const pkgs = options.resolve(dependencies)
         if (pkgs) {
           NodeJs_pkgs = pkgs
         }
       }
+      */
 
       CJS_modules.push(...builtins.concat(NodeJs_pkgs))
 
@@ -308,8 +240,7 @@ export default function useNodeJs(options: UseNodeJsOptions = {}): Plugin[] {
           if (cache) return cache
 
           const workerCount = getWorkerIncrementCount()
-          const _M_ = typeof workerCount === 'number' ? `_M_$${workerCount}` : '_M_'
-          const _D_ = typeof workerCount === 'number' ? `_D_$${workerCount}` : '_D_'
+          const _M_ID = typeof workerCount === 'number' ? `$${workerCount}` : ''
 
           /**
            * 🤔
@@ -317,21 +248,14 @@ export default function useNodeJs(options: UseNodeJsOptions = {}): Plugin[] {
            * Object.keys(await import('fs-extra')).length === 32
            */
           const nodeModule = createRequire(import.meta.url)(id)
-          const requireModule = `const ${_M_} = require("${id}");`
-          const exportDefault = `const ${_D_} = ${_M_}.default || ${_M_};\nexport { ${_D_} as default };`
-          const exportMembers = Object
-            .keys(nodeModule)
-            // https://github.com/electron-vite/electron-vite-react/issues/48
-            .filter(n => !keywords.includes(n))
-            .map(attr => `export const ${attr} = ${_M_}.${attr};`).join('\n')
-          const nodeModuleCodeSnippet = `
-${requireModule}
-${exportDefault}
-${exportMembers}
-`
+          const result = libEsm({ exports: Object.keys(nodeModule), conflict: _M_ID })
+          const nodeModuleSnippet = `
+const _M_${_M_ID} = require("${id}");
+${result.exports}
+`.trim()
 
-          moduleCache.set(id, nodeModuleCodeSnippet)
-          return nodeModuleCodeSnippet
+          moduleCache.set(id, nodeModuleSnippet)
+          return nodeModuleSnippet
         }
       }
 
@@ -352,13 +276,13 @@ ${exportMembers}
   ]
 }
 
-export function resolveModules(root: string, options: UseNodeJsOptions = {}) {
+export function resolveModules(root: string) {
   const cjs_require = createRequire(import.meta.url)
   const cwd = process.cwd()
   const builtins = builtinModules.filter(e => !e.startsWith('_')); builtins.push('electron', ...builtins.map(m => `node:${m}`))
   // dependencies of package.json
-  let dependencies: string[] = []
-  // dependencies(ESM) of package.json
+  const dependencies: string[] = []
+  // dependencies({ "type": "module" }) of package.json
   const ESM_deps: string[] = []
 
   // Resolve package.json dependencies
@@ -377,15 +301,8 @@ export function resolveModules(root: string, options: UseNodeJsOptions = {}) {
           continue
         }
       }
-
-      // TODO: Nested package name, but you can explicity include it by `options.resolve`
       dependencies.push(npmPkg)
     }
-  }
-
-  if (options.resolve) {
-    const tmp = options.resolve(dependencies)
-    if (tmp) dependencies = tmp
   }
 
   return {

--- a/packages/electron-renderer/tsconfig.json
+++ b/packages/electron-renderer/tsconfig.json
@@ -14,5 +14,5 @@
     "strict": true
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["src/build-config.vite-3.0.5.ts"]
+  "exclude": ["exclude", "src/build-config.vite-3.0.5.ts"]
 }

--- a/packages/electron/.gitignore
+++ b/packages/electron/.gitignore
@@ -1,2 +1,3 @@
 /index.mjs
+/index.cjs
 /index.js

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -26,11 +26,8 @@
   "devDependencies": {
     "typescript": "^4.7.4",
     "vite-plugin-electron-renderer": "workspace:*",
-    "vite": "^3.2.0-beta.0",
+    "vite": "^3.1.8",
     "rollup": "^2.77.0"
-  },
-  "peerDependencies": {
-    "vite": ">=3.2.0"
   },
   "files": [
     "src",

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-electron",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Integrate Vite and Electron",
   "main": "index.mjs",
   "types": "src",

--- a/packages/electron/src/config.ts
+++ b/packages/electron/src/config.ts
@@ -1,10 +1,10 @@
+import path from 'node:path'
 import type { AddressInfo } from 'node:net'
 import {
   type InlineConfig,
   type ResolvedConfig,
   type ViteDevServer,
   mergeConfig,
-  normalizePath,
 } from 'vite'
 import { resolveModules } from 'vite-plugin-electron-renderer/plugins/use-node.js'
 import type { Configuration } from '.'
@@ -25,8 +25,8 @@ export function resolveBuildConfig(option: Configuration, resolved: ResolvedConf
         fileName: () => '[name].js',
       },
       emptyOutDir: false,
-      // dist/electron
-      outDir: normalizePath(`${resolved.build.outDir}/electron`),
+      // dist-electron
+      outDir: path.join(`${resolved.root}/dist-electron`),
       minify: resolved.command === 'build', // 🤔 process.env./* from mode option */NODE_ENV === 'production',
     },
   }

--- a/packages/electron/src/config.ts
+++ b/packages/electron/src/config.ts
@@ -1,4 +1,4 @@
-import type { AddressInfo } from 'net'
+import type { AddressInfo } from 'node:net'
 import {
   type InlineConfig,
   type ResolvedConfig,

--- a/packages/electron/vite.config.ts
+++ b/packages/electron/vite.config.ts
@@ -15,12 +15,10 @@ export default defineConfig({
     rollupOptions: {
       external: [
         'electron',
-        'esbuild',
         'vite',
         ...builtinModules,
         ...builtinModules.map(m => `node:${m}`),
         ...Object.keys(pkg.dependencies),
-        // /vite-plugin-electron-renderer/,
       ],
       output: {
         exports: 'named',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,13 +15,13 @@ importers:
       electron: ^21.0.1
       electron-builder: ^23.1.0
       typescript: ^4.7.4
-      vite: ^3.2.0-beta.0
+      vite: ^3.1.8
       vite-plugin-electron: workspace:*
     devDependencies:
       electron: 21.0.1
       electron-builder: 23.1.0
       typescript: 4.7.4
-      vite: 3.2.0-beta.0
+      vite: 3.1.8
       vite-plugin-electron: link:../../packages/electron
 
   examples/nodeIntegration:
@@ -35,10 +35,9 @@ importers:
       node-fetch: ^3.2.8
       serialport: ^10.4.0
       sqlite3: ^5.1.2
-      vite: ^3.2.0-beta.0
+      vite: ^3.1.8
       vite-plugin-electron: workspace:*
       vite-plugin-electron-renderer: workspace:*
-      vite-plugin-esmodule: ^1.4.1
     dependencies:
       serialport: 10.4.0
       sqlite3: 5.1.2
@@ -50,23 +49,22 @@ importers:
       execa: 6.1.0
       got: 12.1.0
       node-fetch: 3.2.8
-      vite: 3.2.0-beta.0
+      vite: 3.1.8
       vite-plugin-electron: link:../../packages/electron
       vite-plugin-electron-renderer: link:../../packages/electron-renderer
-      vite-plugin-esmodule: 1.4.1
 
   examples/quick-start:
     specifiers:
       electron: ^21.0.1
       electron-builder: ^23.1.0
       typescript: ^4.7.4
-      vite: ^3.2.0-beta.0
+      vite: ^3.1.8
       vite-plugin-electron: workspace:*
     devDependencies:
       electron: 21.0.1
       electron-builder: 23.1.0
       typescript: 4.7.4
-      vite: 3.2.0-beta.0
+      vite: 3.1.8
       vite-plugin-electron: link:../../packages/electron
 
   examples/worker:
@@ -74,14 +72,14 @@ importers:
       electron: ^21.0.1
       electron-builder: ^23.1.0
       typescript: ^4.7.4
-      vite: ^3.2.0-beta.0
+      vite: ^3.2.0-beta.3
       vite-plugin-electron: workspace:*
       vite-plugin-electron-renderer: workspace:*
     devDependencies:
       electron: 21.0.1
       electron-builder: 23.1.0
       typescript: 4.7.4
-      vite: 3.2.0-beta.0
+      vite: 3.2.0-beta.3
       vite-plugin-electron: link:../../packages/electron
       vite-plugin-electron-renderer: link:../../packages/electron-renderer
 
@@ -89,25 +87,30 @@ importers:
     specifiers:
       rollup: ^2.77.0
       typescript: ^4.7.4
-      vite: ^3.2.0-beta.0
+      vite: ^3.1.8
       vite-plugin-electron-renderer: workspace:*
     devDependencies:
       rollup: 2.77.0
       typescript: 4.7.4
-      vite: 3.2.0-beta.0
+      vite: 3.1.8
       vite-plugin-electron-renderer: link:../electron-renderer
 
   packages/electron-renderer:
     specifiers:
       esbuild: ^0.15.10
-      rollup: ^2.77.0
+      lib-esm: ~0.3.0
+      rollup: ~2.78.0
       typescript: ^4.7.4
-      vite: ^3.2.0-beta.0
+      vite: ^3.1.8
+      vite-plugin-utils: ^0.3.6
+    dependencies:
+      lib-esm: 0.3.0
     devDependencies:
       esbuild: 0.15.10
-      rollup: 2.79.1
+      rollup: 2.78.1
       typescript: 4.7.4
-      vite: 3.2.0-beta.0
+      vite: 3.1.8
+      vite-plugin-utils: 0.3.6
 
 packages:
 
@@ -178,43 +181,6 @@ packages:
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
     dev: false
     optional: true
-
-  /@jridgewell/gen-mapping/0.3.2:
-    resolution: {integrity: sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==}
-    engines: {node: '>=6.0.0'}
-    dependencies:
-      '@jridgewell/set-array': 1.1.2
-      '@jridgewell/sourcemap-codec': 1.4.14
-      '@jridgewell/trace-mapping': 0.3.14
-    dev: true
-
-  /@jridgewell/resolve-uri/3.1.0:
-    resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==}
-    engines: {node: '>=6.0.0'}
-    dev: true
-
-  /@jridgewell/set-array/1.1.2:
-    resolution: {integrity: sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==}
-    engines: {node: '>=6.0.0'}
-    dev: true
-
-  /@jridgewell/source-map/0.3.2:
-    resolution: {integrity: sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==}
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.2
-      '@jridgewell/trace-mapping': 0.3.14
-    dev: true
-
-  /@jridgewell/sourcemap-codec/1.4.14:
-    resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
-    dev: true
-
-  /@jridgewell/trace-mapping/0.3.14:
-    resolution: {integrity: sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==}
-    dependencies:
-      '@jridgewell/resolve-uri': 3.1.0
-      '@jridgewell/sourcemap-codec': 1.4.14
-    dev: true
 
   /@malept/cross-spawn-promise/1.1.1:
     resolution: {integrity: sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==}
@@ -416,24 +382,6 @@ packages:
       '@types/ms': 0.7.31
     dev: true
 
-  /@types/eslint-scope/3.7.4:
-    resolution: {integrity: sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==}
-    dependencies:
-      '@types/eslint': 8.4.5
-      '@types/estree': 0.0.51
-    dev: true
-
-  /@types/eslint/8.4.5:
-    resolution: {integrity: sha512-dhsC09y1gpJWnK+Ff4SGvCuSnk9DaU0BJZSzOwa6GVSg65XtTugLBITDAAzRU5duGBoXBHpdR/9jHGxJjNflJQ==}
-    dependencies:
-      '@types/estree': 0.0.51
-      '@types/json-schema': 7.0.11
-    dev: true
-
-  /@types/estree/0.0.51:
-    resolution: {integrity: sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==}
-    dev: true
-
   /@types/fs-extra/9.0.13:
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
     dependencies:
@@ -455,10 +403,6 @@ packages:
 
   /@types/json-buffer/3.0.0:
     resolution: {integrity: sha512-3YP80IxxFJB4b5tYC2SUPwkg0XQLiu0nWvhRgEatgjf+29IcWO9X1k8xRv5DGssJ/lCrjYTjQPcobJr2yWIVuQ==}
-    dev: true
-
-  /@types/json-schema/7.0.11:
-    resolution: {integrity: sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==}
     dev: true
 
   /@types/keyv/3.1.4:
@@ -527,137 +471,9 @@ packages:
     dev: true
     optional: true
 
-  /@webassemblyjs/ast/1.11.1:
-    resolution: {integrity: sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==}
-    dependencies:
-      '@webassemblyjs/helper-numbers': 1.11.1
-      '@webassemblyjs/helper-wasm-bytecode': 1.11.1
-    dev: true
-
-  /@webassemblyjs/floating-point-hex-parser/1.11.1:
-    resolution: {integrity: sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==}
-    dev: true
-
-  /@webassemblyjs/helper-api-error/1.11.1:
-    resolution: {integrity: sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==}
-    dev: true
-
-  /@webassemblyjs/helper-buffer/1.11.1:
-    resolution: {integrity: sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==}
-    dev: true
-
-  /@webassemblyjs/helper-numbers/1.11.1:
-    resolution: {integrity: sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==}
-    dependencies:
-      '@webassemblyjs/floating-point-hex-parser': 1.11.1
-      '@webassemblyjs/helper-api-error': 1.11.1
-      '@xtuc/long': 4.2.2
-    dev: true
-
-  /@webassemblyjs/helper-wasm-bytecode/1.11.1:
-    resolution: {integrity: sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==}
-    dev: true
-
-  /@webassemblyjs/helper-wasm-section/1.11.1:
-    resolution: {integrity: sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==}
-    dependencies:
-      '@webassemblyjs/ast': 1.11.1
-      '@webassemblyjs/helper-buffer': 1.11.1
-      '@webassemblyjs/helper-wasm-bytecode': 1.11.1
-      '@webassemblyjs/wasm-gen': 1.11.1
-    dev: true
-
-  /@webassemblyjs/ieee754/1.11.1:
-    resolution: {integrity: sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==}
-    dependencies:
-      '@xtuc/ieee754': 1.2.0
-    dev: true
-
-  /@webassemblyjs/leb128/1.11.1:
-    resolution: {integrity: sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==}
-    dependencies:
-      '@xtuc/long': 4.2.2
-    dev: true
-
-  /@webassemblyjs/utf8/1.11.1:
-    resolution: {integrity: sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==}
-    dev: true
-
-  /@webassemblyjs/wasm-edit/1.11.1:
-    resolution: {integrity: sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==}
-    dependencies:
-      '@webassemblyjs/ast': 1.11.1
-      '@webassemblyjs/helper-buffer': 1.11.1
-      '@webassemblyjs/helper-wasm-bytecode': 1.11.1
-      '@webassemblyjs/helper-wasm-section': 1.11.1
-      '@webassemblyjs/wasm-gen': 1.11.1
-      '@webassemblyjs/wasm-opt': 1.11.1
-      '@webassemblyjs/wasm-parser': 1.11.1
-      '@webassemblyjs/wast-printer': 1.11.1
-    dev: true
-
-  /@webassemblyjs/wasm-gen/1.11.1:
-    resolution: {integrity: sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==}
-    dependencies:
-      '@webassemblyjs/ast': 1.11.1
-      '@webassemblyjs/helper-wasm-bytecode': 1.11.1
-      '@webassemblyjs/ieee754': 1.11.1
-      '@webassemblyjs/leb128': 1.11.1
-      '@webassemblyjs/utf8': 1.11.1
-    dev: true
-
-  /@webassemblyjs/wasm-opt/1.11.1:
-    resolution: {integrity: sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==}
-    dependencies:
-      '@webassemblyjs/ast': 1.11.1
-      '@webassemblyjs/helper-buffer': 1.11.1
-      '@webassemblyjs/wasm-gen': 1.11.1
-      '@webassemblyjs/wasm-parser': 1.11.1
-    dev: true
-
-  /@webassemblyjs/wasm-parser/1.11.1:
-    resolution: {integrity: sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==}
-    dependencies:
-      '@webassemblyjs/ast': 1.11.1
-      '@webassemblyjs/helper-api-error': 1.11.1
-      '@webassemblyjs/helper-wasm-bytecode': 1.11.1
-      '@webassemblyjs/ieee754': 1.11.1
-      '@webassemblyjs/leb128': 1.11.1
-      '@webassemblyjs/utf8': 1.11.1
-    dev: true
-
-  /@webassemblyjs/wast-printer/1.11.1:
-    resolution: {integrity: sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==}
-    dependencies:
-      '@webassemblyjs/ast': 1.11.1
-      '@xtuc/long': 4.2.2
-    dev: true
-
-  /@xtuc/ieee754/1.2.0:
-    resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
-    dev: true
-
-  /@xtuc/long/4.2.2:
-    resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
-    dev: true
-
   /abbrev/1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
     dev: false
-
-  /acorn-import-assertions/1.8.0_acorn@8.7.1:
-    resolution: {integrity: sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==}
-    peerDependencies:
-      acorn: ^8
-    dependencies:
-      acorn: 8.7.1
-    dev: true
-
-  /acorn/8.7.1:
-    resolution: {integrity: sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-    dev: true
 
   /agent-base/6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
@@ -899,17 +715,6 @@ packages:
       balanced-match: 1.0.2
     dev: true
 
-  /browserslist/4.21.2:
-    resolution: {integrity: sha512-MonuOgAtUB46uP5CezYbRaYKBNt2LxP0yX+Pmj4LkcDFGkn9Cbpi83d9sCjwQDErXsIJSzY5oKGDbgOlF/LPAA==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
-    dependencies:
-      caniuse-lite: 1.0.30001367
-      electron-to-chromium: 1.4.192
-      node-releases: 2.0.6
-      update-browserslist-db: 1.0.4_browserslist@4.21.2
-    dev: true
-
   /buffer-alloc-unsafe/1.1.0:
     resolution: {integrity: sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==}
     dev: true
@@ -1043,10 +848,6 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /caniuse-lite/1.0.30001367:
-    resolution: {integrity: sha512-XDgbeOHfifWV3GEES2B8rtsrADx4Jf+juKX2SICJcaUhjYBO3bR96kvEIHa15VU6ohtOhBZuPGGYGbXMRn0NCw==}
-    dev: true
-
   /chalk/4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -1058,11 +859,6 @@ packages:
   /chownr/2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
     engines: {node: '>=10'}
-
-  /chrome-trace-event/1.0.3:
-    resolution: {integrity: sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==}
-    engines: {node: '>=6.0'}
-    dev: true
 
   /chromium-pickle-js/0.2.0:
     resolution: {integrity: sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==}
@@ -1136,10 +932,6 @@ packages:
     engines: {node: '>= 0.8'}
     dependencies:
       delayed-stream: 1.0.0
-    dev: true
-
-  /commander/2.20.3:
-    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
     dev: true
 
   /commander/2.9.0:
@@ -1468,10 +1260,6 @@ packages:
       type-fest: 2.16.0
     dev: true
 
-  /electron-to-chromium/1.4.192:
-    resolution: {integrity: sha512-8nCXyIQY9An88NXAp+PuPy5h3/w5ZY7Iu2lag65Q0XREprcat5F8gKhoHsBUnQcFuCRnmevpR8yEBYRU3d2HDw==}
-    dev: true
-
   /electron/21.0.1:
     resolution: {integrity: sha512-jLVSLakd0fO2GPnW4xXQrI93R464jeFb2ISngqRP3wpwH96XqeANkuAYLAr9TVhfQMCIWnuPROBZ+NU7nuk0WA==}
     engines: {node: '>= 10.17.0'}
@@ -1508,14 +1296,6 @@ packages:
       once: 1.4.0
     dev: true
 
-  /enhanced-resolve/5.10.0:
-    resolution: {integrity: sha512-T0yTFjdpldGY8PmuXXR0PyQ1ufZpEGiHVrp7zHKB7jdR4qlmZHhONVM5AQOAWXuF/w3dnHbEQVrNptJgt7F+cQ==}
-    engines: {node: '>=10.13.0'}
-    dependencies:
-      graceful-fs: 4.2.10
-      tapable: 2.2.1
-    dev: true
-
   /env-paths/2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
@@ -1524,10 +1304,6 @@ packages:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
     dev: false
     optional: true
-
-  /es-module-lexer/0.9.3:
-    resolution: {integrity: sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==}
-    dev: true
 
   /es6-error/4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
@@ -1760,36 +1536,6 @@ packages:
     dev: true
     optional: true
 
-  /eslint-scope/5.1.1:
-    resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
-    engines: {node: '>=8.0.0'}
-    dependencies:
-      esrecurse: 4.3.0
-      estraverse: 4.3.0
-    dev: true
-
-  /esrecurse/4.3.0:
-    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
-    engines: {node: '>=4.0'}
-    dependencies:
-      estraverse: 5.3.0
-    dev: true
-
-  /estraverse/4.3.0:
-    resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==}
-    engines: {node: '>=4.0'}
-    dev: true
-
-  /estraverse/5.3.0:
-    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
-    engines: {node: '>=4.0'}
-    dev: true
-
-  /events/3.3.0:
-    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
-    engines: {node: '>=0.8.x'}
-    dev: true
-
   /execa/6.1.0:
     resolution: {integrity: sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -1990,10 +1736,6 @@ packages:
   /get-stream/6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
-    dev: true
-
-  /glob-to-regexp/0.4.1:
-    resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
     dev: true
 
   /glob/7.2.3:
@@ -2343,15 +2085,6 @@ packages:
       minimatch: 3.1.2
     dev: true
 
-  /jest-worker/27.5.1:
-    resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
-    engines: {node: '>= 10.13.0'}
-    dependencies:
-      '@types/node': 18.0.6
-      merge-stream: 2.0.0
-      supports-color: 8.1.1
-    dev: true
-
   /js-yaml/4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
@@ -2365,10 +2098,6 @@ packages:
 
   /json-buffer/3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
-    dev: true
-
-  /json-parse-even-better-errors/2.3.1:
-    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
     dev: true
 
   /json-schema-traverse/0.4.1:
@@ -2432,10 +2161,9 @@ packages:
     resolution: {integrity: sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==}
     dev: true
 
-  /loader-runner/4.3.0:
-    resolution: {integrity: sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==}
-    engines: {node: '>=6.11.5'}
-    dev: true
+  /lib-esm/0.3.0:
+    resolution: {integrity: sha512-P7YcG7OnoaGL2h4j46g/m0P2xHMXlYf+0iCDvVrEfzUVxLe+abytgd2VjUhj9puqEgqRGEDbT504YWj75jHacA==}
+    dev: false
 
   /locate-path/3.0.0:
     resolution: {integrity: sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==}
@@ -2660,10 +2388,6 @@ packages:
     dev: false
     optional: true
 
-  /neo-async/2.6.2:
-    resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
-    dev: true
-
   /node-addon-api/1.7.2:
     resolution: {integrity: sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==}
     dev: true
@@ -2725,10 +2449,6 @@ packages:
       - supports-color
     dev: false
     optional: true
-
-  /node-releases/2.0.6:
-    resolution: {integrity: sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==}
-    dev: true
 
   /nopt/5.0.0:
     resolution: {integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==}
@@ -2913,8 +2633,8 @@ packages:
       xmlbuilder: 15.1.1
     dev: true
 
-  /postcss/8.4.17:
-    resolution: {integrity: sha512-UNxNOLQydcOFi41yHNMcKRZ39NeXlr8AxGuZJsdub8vIb12fHzcq37DTU/QtbI6WLxNg2gF9Z+8qtRwTj1UI1Q==}
+  /postcss/8.4.18:
+    resolution: {integrity: sha512-Wi8mWhncLJm11GATDaQKobXSNEYGUHeQLiQqDFG1qQ5UTDPTEvKw0Xt5NsTpktGTwLps3ByrWsBrG0rB8YQ9oA==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
       nanoid: 3.3.4
@@ -2978,12 +2698,6 @@ packages:
   /quick-lru/5.1.1:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
-    dev: true
-
-  /randombytes/2.1.0:
-    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
-    dependencies:
-      safe-buffer: 5.2.1
     dev: true
 
   /rc/1.2.8:
@@ -3098,6 +2812,14 @@ packages:
       fsevents: 2.3.2
     dev: true
 
+  /rollup/2.78.1:
+    resolution: {integrity: sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
   /rollup/2.79.1:
     resolution: {integrity: sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==}
     engines: {node: '>=10.0.0'}
@@ -3108,6 +2830,7 @@ packages:
 
   /safe-buffer/5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+    dev: false
 
   /safer-buffer/2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -3120,15 +2843,6 @@ packages:
 
   /sax/1.2.4:
     resolution: {integrity: sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==}
-    dev: true
-
-  /schema-utils/3.1.1:
-    resolution: {integrity: sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==}
-    engines: {node: '>= 10.13.0'}
-    dependencies:
-      '@types/json-schema': 7.0.11
-      ajv: 6.12.6
-      ajv-keywords: 3.5.2_ajv@6.12.6
     dev: true
 
   /semver-compare/1.0.0:
@@ -3161,12 +2875,6 @@ packages:
       type-fest: 0.13.1
     dev: true
     optional: true
-
-  /serialize-javascript/6.0.0:
-    resolution: {integrity: sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==}
-    dependencies:
-      randombytes: 2.1.0
-    dev: true
 
   /serialport/10.4.0:
     resolution: {integrity: sha512-PszPM5SnFMgSXom60PkKS2A9nMlNbHkuoyRBlzdSWw9rmgOn258+V0dYbWMrETJMM+TJV32vqBzjg5MmmUMwMw==}
@@ -3344,21 +3052,9 @@ packages:
       has-flag: 4.0.0
     dev: true
 
-  /supports-color/8.1.1:
-    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
-    engines: {node: '>=10'}
-    dependencies:
-      has-flag: 4.0.0
-    dev: true
-
   /supports-preserve-symlinks-flag/1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
-    dev: true
-
-  /tapable/2.2.1:
-    resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
-    engines: {node: '>=6'}
     dev: true
 
   /tar/6.1.11:
@@ -3377,41 +3073,6 @@ packages:
     dependencies:
       async-exit-hook: 2.0.1
       fs-extra: 10.1.0
-    dev: true
-
-  /terser-webpack-plugin/5.3.3_webpack@5.73.0:
-    resolution: {integrity: sha512-Fx60G5HNYknNTNQnzQ1VePRuu89ZVYWfjRAeT5rITuCY/1b08s49e5kSQwHDirKZWuoKOBRFS98EUUoZ9kLEwQ==}
-    engines: {node: '>= 10.13.0'}
-    peerDependencies:
-      '@swc/core': '*'
-      esbuild: '*'
-      uglify-js: '*'
-      webpack: ^5.1.0
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      esbuild:
-        optional: true
-      uglify-js:
-        optional: true
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.14
-      jest-worker: 27.5.1
-      schema-utils: 3.1.1
-      serialize-javascript: 6.0.0
-      terser: 5.14.2
-      webpack: 5.73.0
-    dev: true
-
-  /terser/5.14.2:
-    resolution: {integrity: sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==}
-    engines: {node: '>=10'}
-    hasBin: true
-    dependencies:
-      '@jridgewell/source-map': 0.3.2
-      acorn: 8.7.1
-      commander: 2.20.3
-      source-map-support: 0.5.21
     dev: true
 
   /tmp-promise/3.0.3:
@@ -3507,17 +3168,6 @@ packages:
     engines: {node: '>= 10.0.0'}
     dev: true
 
-  /update-browserslist-db/1.0.4_browserslist@4.21.2:
-    resolution: {integrity: sha512-jnmO2BEGUjsMOe/Fg9u0oczOe/ppIDZPebzccl1yDWGLFP16Pa1/RM5wEoKYPG2zstNcDuAStejyxsOuKINdGA==}
-    hasBin: true
-    peerDependencies:
-      browserslist: '>= 4.21.0'
-    dependencies:
-      browserslist: 4.21.2
-      escalade: 3.1.1
-      picocolors: 1.0.0
-    dev: true
-
   /update-notifier/5.1.0:
     resolution: {integrity: sha512-ItnICHbeMh9GqUy31hFPrD1kcuZ3rpxDZbf4KUDavXwS0bW5m7SLbDQpGX3UYr072cbrF5hFUs3r5tUsPwjfHw==}
     engines: {node: '>=10'}
@@ -3569,24 +3219,39 @@ packages:
     dev: true
     optional: true
 
-  /vite-plugin-esmodule/1.4.1:
-    resolution: {integrity: sha512-CLGW8tWLQ6Z52CyhSsCySR54+TVxfMRHTIRxY81mT8RFj9r7H6oXI3TFb9MzoJu/esfzQI3GOIOyhgLZpHCqlg==}
+  /vite-plugin-utils/0.3.6:
+    resolution: {integrity: sha512-+tZdnTxrDdjPzrlPUyvm52SvOVRibDEnA9NdzQt85UoqXwLGJp4RAkT9fK11KdLMTdJlb9DxCvHrDfsn/lSKug==}
+    dev: true
+
+  /vite/3.1.8:
+    resolution: {integrity: sha512-m7jJe3nufUbuOfotkntGFupinL/fmuTNuQmiVE7cH2IZMuf4UbfbGYMUT3jVWgGYuRVLY9j8NnrRqgw5rr5QTg==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      less: '*'
+      sass: '*'
+      stylus: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      less:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      terser:
+        optional: true
     dependencies:
-      vite-plugin-optimizer: 1.4.0
-      webpack: 5.73.0
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-      - webpack-cli
+      esbuild: 0.15.10
+      postcss: 8.4.18
+      resolve: 1.22.1
+      rollup: 2.78.1
+    optionalDependencies:
+      fsevents: 2.3.2
     dev: true
 
-  /vite-plugin-optimizer/1.4.0:
-    resolution: {integrity: sha512-hTY1pdtSmN/BNOnjvmcmK+2fW1Ac9wD0gFBy67i5IsKwhr1fS1/GGmssdCaik2SpnplHjoDrmCgVsgBv20HzrA==}
-    dev: true
-
-  /vite/3.2.0-beta.0:
-    resolution: {integrity: sha512-sIqxi9gLVl+ysDfioIpZjDN8PxF5ary2zRoHVWspqWteKuoCul4ExyXBK7+hkRHHJEJbbJABY2+vWAb/2sYmPg==}
+  /vite/3.2.0-beta.3:
+    resolution: {integrity: sha512-c9KRnMUlbxLNqzCihTozhKlRdOzjAWsO3H9cC/ej+JuvL4rnIxSvv+9m5Wz2PAs9lgDD7Yk0VZuzKYSSk3peWw==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
     peerDependencies:
@@ -3608,19 +3273,11 @@ packages:
         optional: true
     dependencies:
       esbuild: 0.15.10
-      postcss: 8.4.17
+      postcss: 8.4.18
       resolve: 1.22.1
       rollup: 2.79.1
     optionalDependencies:
       fsevents: 2.3.2
-    dev: true
-
-  /watchpack/2.4.0:
-    resolution: {integrity: sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==}
-    engines: {node: '>=10.13.0'}
-    dependencies:
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.10
     dev: true
 
   /web-streams-polyfill/3.2.1:
@@ -3631,51 +3288,6 @@ packages:
   /webidl-conversions/3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
     dev: false
-
-  /webpack-sources/3.2.3:
-    resolution: {integrity: sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==}
-    engines: {node: '>=10.13.0'}
-    dev: true
-
-  /webpack/5.73.0:
-    resolution: {integrity: sha512-svjudQRPPa0YiOYa2lM/Gacw0r6PvxptHj4FuEKQ2kX05ZLkjbVc5MnPs6its5j7IZljnIqSVo/OsY2X0IpHGA==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-    peerDependencies:
-      webpack-cli: '*'
-    peerDependenciesMeta:
-      webpack-cli:
-        optional: true
-    dependencies:
-      '@types/eslint-scope': 3.7.4
-      '@types/estree': 0.0.51
-      '@webassemblyjs/ast': 1.11.1
-      '@webassemblyjs/wasm-edit': 1.11.1
-      '@webassemblyjs/wasm-parser': 1.11.1
-      acorn: 8.7.1
-      acorn-import-assertions: 1.8.0_acorn@8.7.1
-      browserslist: 4.21.2
-      chrome-trace-event: 1.0.3
-      enhanced-resolve: 5.10.0
-      es-module-lexer: 0.9.3
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.10
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.0
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 3.1.1
-      tapable: 2.2.1
-      terser-webpack-plugin: 5.3.3_webpack@5.73.0
-      watchpack: 2.4.0
-      webpack-sources: 3.2.3
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-    dev: true
 
   /whatwg-url/5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}


### PR DESCRIPTION
## 0.10.2 (2022-10-24)

1. Remove Vite `3.2.0` | #90
2. ad9bb3c refactor(electron-renderer)!: remove `options.resolve()`, use 'lib-esm' for resolve Node.js modules and `electron` | vite-plugin-electron-renderer
3. b500039 feat(electron-renderer): support `optimizeDeps` for Electron-Renderer 🚀
4. f28e66b faet(outDir)!: `dist/electron` -> `dist/electron` | vite-plugin-electron

## Better resolve Node.js npm-packages in Electron-Renderer 🚀

```js
export default {
  plugins: [
    renderer({
      // Enables use of Node.js API in the Renderer-process
      nodeIntegration: true,
      // Like Vite's pre bundling
      optimizeDeps: {
        include: [
          'serialport',     // cjs(C++)
          'electron-store', // cjs
          'execa',          // esm
          'got',            // esm
          'node-fetch',     // esm
        ],
      },
    }),
  ],
}
```