### PR TITLE
fix: ignore the browser field when bundling

### DIFF
--- a/packages/electron/src/config.ts
+++ b/packages/electron/src/config.ts
@@ -26,7 +26,7 @@ export function resolveBuildConfig(option: Configuration, resolved: ResolvedConf
       },
       resolve: {
         // Since we're building for electron (which uses nodejs), we don't want to use the "browser" field in the packages.
-        // It corrupts bundling for packages like `ws` and `isomorphic-ws`, for example.
+        // It corrupts bundling packages like `ws` and `isomorphic-ws`, for example.
         browserField: false,
         mainFields: ["module", "jsnext:main", "jsnext"],
       },

--- a/packages/electron/src/config.ts
+++ b/packages/electron/src/config.ts
@@ -24,6 +24,12 @@ export function resolveBuildConfig(option: Configuration, resolved: ResolvedConf
         formats: ['cjs'],
         fileName: () => '[name].js',
       },
+      resolve: {
+        // Since we're building for electron (which uses nodejs), we don't want to use the "browser" field in the packages.
+        // It makes our build fail for the `ws` and `isomorphic-ws` packages, for example.
+        browserField: false,
+        mainFields: ["module", "jsnext:main", "jsnext"],
+      },
       emptyOutDir: false,
       // dist-electron
       outDir: path.join(`${resolved.root}/dist-electron`),

--- a/packages/electron/src/config.ts
+++ b/packages/electron/src/config.ts
@@ -26,7 +26,7 @@ export function resolveBuildConfig(option: Configuration, resolved: ResolvedConf
       },
       resolve: {
         // Since we're building for electron (which uses nodejs), we don't want to use the "browser" field in the packages.
-        // It makes our build fail for the `ws` and `isomorphic-ws` packages, for example.
+        // It corrupts bundling for packages like `ws` and `isomorphic-ws`, for example.
         browserField: false,
         mainFields: ["module", "jsnext:main", "jsnext"],
       },


### PR DESCRIPTION
Vite will use the "browser" field in the packages bundled for electron (eg, main and preload). That behavior is problematic for packages like "ws" or "isomorphic-ws", which provide a browser field in their package.json pointing to file that throws an error on purpose.

This PR tells Vite to ignore the browser field.