### PR TITLE
Fix react-refresh in development

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -26,6 +26,7 @@ export async function bootstrap(config: Configuration | Configuration[], server:
     const inlineConfig = withExternalBuiltins(resolveViteConfig(config))
     await viteBuild(mergeConfig(
       {
+        mode: 'development',
         build: {
           watch: {},
         },


### PR DESCRIPTION
When using `vite` to start a dev server using `@vitejs/plugin-react` and `vite-plugin-electron`, React apps fail to load with this error:

```
Uncaught TypeError: RefreshRuntime.injectIntoGlobalHook is not a function
```

The react refresh runtime has a check and only initializes most methods (including `injectIntoGlobalHook` if the current environment is not `production`.

Normally using `vite` the mode would automatically be `development`, but since this plugin dispatches a custom build on startup, the dev mode is not propagated to this custom build. This fixes that for the `serve` command, which I think is the only place this is necessary.