### PR TITLE
Fix: Use mode from source config

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -26,7 +26,7 @@ export async function bootstrap(config: Configuration | Configuration[], server:
     const inlineConfig = withExternalBuiltins(resolveViteConfig(config))
     await viteBuild(mergeConfig(
       {
-        mode: 'development',
+        mode: server.config.mode,
         build: {
           watch: {},
         },


### PR DESCRIPTION
Sorry, this is a follow-up from my last PR.

I noticed that when hard-coding the mode to `development`, this applied to both `vite` and `vite build` commands, and applied regardless of the original user's `vite.config`.

This change makes the value used by `vite-plugin-electron` follow those. So running `vite`, the mode will be `development`; running `vite build`, the mode will be `production`; and if the user specifies one of these, that mode should be used.