### PR TITLE
V0.11.0 beta1

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ export interface Configuration {
     startup: (argv?: string[]) => Promise<void>
     /** Reload Electron-Renderer */
     reload: () => void
-  }) => void
+  }) => void | Promise<void>
 }
 ```
 

--- a/src/build.ts
+++ b/src/build.ts
@@ -6,11 +6,6 @@ import {
 } from './config'
 
 /** Work on the `vite build` command */
-export async function build(config: Configuration | Configuration[]) {
-  const configArray = Array.isArray(config) ? config : [config]
-
-  for (const config of configArray) {
-    const inlineConfig = withExternalBuiltins(resolveViteConfig(config))
-    await viteBuild(inlineConfig)
-  }
+export function build(config: Configuration) {
+  return viteBuild(withExternalBuiltins(resolveViteConfig(config)))
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,7 +27,7 @@ export interface Configuration {
     startup: (argv?: string[]) => Promise<void>
     /** Reload Electron-Renderer */
     reload: () => void
-  }) => void
+  }) => void | Promise<void>
 }
 
 export function defineConfig(config: Configuration) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,17 +4,26 @@ import { bootstrap } from './serve'
 import type { Configuration } from './config'
 
 // public
-export { type Configuration, defineConfig, resolveViteConfig, withExternalBuiltins } from './config'
+export {
+  type Configuration,
+  defineConfig,
+  resolveViteConfig,
+  withExternalBuiltins,
+} from './config'
 export { build }
 
 export default function electron(config: Configuration | Configuration[]): Plugin[] {
+  const configArray = Array.isArray(config) ? config : [config]
+
   return [
     {
       name: 'vite-plugin-electron',
       apply: 'serve',
       configureServer(server) {
         server.httpServer?.once('listening', () => {
-          bootstrap(config, server)
+          for (const config of configArray) {
+            bootstrap(config, server)
+          }
         })
       },
     },
@@ -26,7 +35,9 @@ export default function electron(config: Configuration | Configuration[]): Plugi
         config.base ??= './'
       },
       async closeBundle() {
-        await build(config)
+        for (const config of configArray) {
+          await build(config)
+        }
       }
     },
   ]

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -30,9 +30,9 @@ export async function bootstrap(config: Configuration | Configuration[], server:
         },
         plugins: [{
           name: ':startup',
-          closeBundle() {
+          async closeBundle() {
             if (config.onstart) {
-              config.onstart.call(this, {
+              await config.onstart.call(this, {
                 startup,
                 reload() {
                   server.ws.send({ type: 'full-reload' })

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -13,48 +13,44 @@ import {
 } from './config'
 
 /** Work on the `vite serve` command */
-export async function bootstrap(config: Configuration | Configuration[], server: ViteDevServer) {
+export function bootstrap(config: Configuration, server: ViteDevServer) {
   Object.assign(process.env, {
     VITE_DEV_SERVER_URL: resolveServerUrl(server)
   })
 
-  const configArray = Array.isArray(config) ? config : [config]
-
-  for (const config of configArray) {
-    const inlineConfig = withExternalBuiltins(resolveViteConfig(config))
-    await viteBuild(mergeConfig(
-      {
-        mode: server.config.mode,
-        build: {
-          watch: {},
-        },
-        plugins: [{
-          name: ':startup',
-          async closeBundle() {
-            if (config.onstart) {
-              await config.onstart.call(this, {
-                startup,
-                reload() {
-                  server.ws.send({ type: 'full-reload' })
-                },
-              })
-            } else {
-              // TODO: 2022-10-12 Rollup can't accurately distinguish a file with multiple entries
-              if (false/* path.parse(filename).name.endsWith('reload') */) {
-                // Bundle filename that ends with `reload` will trigger the Electron-Renderer process to reload, 
-                // instead of restarting the entire Electron App.
-                // e.g.
-                //   dist/electron/preload.ts
-                //   dist/electron/foo.reload.js
+  const inlineConfig = withExternalBuiltins(resolveViteConfig(config))
+  return viteBuild(mergeConfig(
+    <UserConfig>{
+      mode: server.config.mode,
+      build: {
+        watch: {},
+      },
+      plugins: [{
+        name: ':startup',
+        closeBundle() {
+          if (config.onstart) {
+            config.onstart.call(this, {
+              startup,
+              reload() {
                 server.ws.send({ type: 'full-reload' })
-              } else {
-                startup()
-              }
+              },
+            })
+          } else {
+            // TODO: 2022-10-12 Rollup can't accurately distinguish a file with multiple entries
+            if (false/* path.parse(filename).name.endsWith('reload') */) {
+              // Bundle filename that ends with `reload` will trigger the Electron-Renderer process to reload, 
+              // instead of restarting the entire Electron App.
+              // e.g.
+              //   dist/electron/preload.ts
+              //   dist/electron/foo.reload.js
+              server.ws.send({ type: 'full-reload' })
+            } else {
+              startup()
             }
-          },
-        }],
-      } as UserConfig,
-      inlineConfig,
-    ))
-  }
+          }
+        },
+      }],
+    },
+    inlineConfig,
+  ))
 }


### PR DESCRIPTION
**Break**
d9c3343 refactor!: returns Vite build results, using only a single config params