### PR TITLE
V0.11.0

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+# For electron-builder
+# https://github.com/electron-userland/electron-builder/issues/6289#issuecomment-1042620422
+shamefully-hoist=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,65 @@
+## 0.11.0 (2022-12-17)
+
+#### Break!
+
+```ts
+// 0.10.0
+function build(config: Configuration | Configuration[]): Promise<void>
+
+// 0.11.0 - Same as Vite's build
+function build(config: Configuration): Promise<RollupOutput | RollupOutput[] | RollupWatcher>
+```
+
+#### Features
+
+**JavaScript API**
+
+`vite-plugin-electron`'s JavaScript APIs are fully typed, and it's recommended to use TypeScript or enable JS type checking in VS Code to leverage the intellisense and validation.
+
+- `Configuration` - type
+- `defineConfig` - function
+- `resolveViteConfig` - function, Resolve the default Vite's `InlineConfig` for build Electron-Main
+- `withExternalBuiltins` - function
+- `build` - function
+
+Example:
+
+```js
+build(
+  withExternalBuiltins( // external Node.js builtin modules
+    resolveViteConfig( // with default config
+      {
+        entry: 'foo.ts',
+        vite: {
+          mode: 'foo-mode', // for .env file
+          plugins: [{
+            name: 'plugin-build-done',
+            closeBundle() {
+              // Do something...
+            },
+          }],
+        },
+      }
+    )
+  )
+)
+```
+
+**V8 Bytecode support** 👉 [bytecode](https://github.com/electron-vite/vite-plugin-electron/tree/main/examples/bytecode)
+
+Inspired by:
+
+- [Nihiue/little-byte-demo](https://github.com/Nihiue/little-byte-demo)
+- [通过字节码保护Node.js源码之原理篇 - 知乎](https://zhuanlan.zhihu.com/p/359235114)
+
+#### Commit/PR
+
+- Support Vite4.x | #118, 28d38b6
+- Bytecode example | df170c2
+- JavaScript API docs | 3049169
+- Fix load `.env` | 758695d
+- Refactor `build()` | d9c3343
+
 ## 0.10.4 (2022-11-13)
 
 - e4f943f refactor: move `build.resolve` to `resolve`

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ npm i vite-plugin-electron -D
 
 - [quick-start](https://github.com/electron-vite/vite-plugin-electron/tree/main/examples/quick-start)
 - [custom-start-electron-app](https://github.com/electron-vite/vite-plugin-electron/tree/main/examples/custom-start-electron-app)
+- [bytecode](https://github.com/electron-vite/vite-plugin-electron/tree/main/examples/bytecode)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,39 @@ export interface Configuration {
 }
 ```
 
+## JavaScript API
+
+`vite-plugin-electron`'s JavaScript APIs are fully typed, and it's recommended to use TypeScript or enable JS type checking in VS Code to leverage the intellisense and validation.
+
+- `Configuration` - type
+- `defineConfig` - function
+- `resolveViteConfig` - function, Resolve the default Vite's `InlineConfig` for build Electron-Main
+- `withExternalBuiltins` - function
+- `build` - function
+
+**Example**
+
+```js
+build(
+  withExternalBuiltins( // external Node.js builtin modules
+    resolveViteConfig( // with default config
+      {
+        entry: 'foo.ts',
+        vite: {
+          mode: 'foo-mode', // for .env file
+          plugins: [{
+            name: 'plugin-build-done',
+            closeBundle() {
+              // Do something...
+            },
+          }],
+        },
+      }
+    )
+  )
+)
+```
+
 ## How to work
 
 It just executes the `electron .` command in the Vite build completion hook and then starts or restarts the Electron App.

--- a/examples/quick-start/vite.config.ts
+++ b/examples/quick-start/vite.config.ts
@@ -1,28 +1,5 @@
-import {
-  type Plugin,
-  defineConfig,
-  loadEnv,
-} from 'vite'
+import { defineConfig } from 'vite'
 import electron from 'vite-plugin-electron'
-
-// Load .env
-function loadEnvPlugin(): Plugin {
-  return {
-    name: 'vite-plugin-load-env',
-    config(config, env) {
-      const root = config.root ?? process.cwd()
-      const result = loadEnv(env.mode, root)
-      // Remove the vite-plugin-electron injected env.
-      delete result.VITE_DEV_SERVER_URL
-      config.esbuild ??= {}
-      config.esbuild.define = {
-        ...config.esbuild.define,
-        ...Object.fromEntries(Object.entries(result)
-          .map(([key, val]) => [`process.env.${key}`, JSON.stringify(val)])),
-      }
-    },
-  }
-}
 
 export default defineConfig({
   plugins: [
@@ -30,9 +7,6 @@ export default defineConfig({
       {
         // Main-Process entry file of the Electron App.
         entry: 'electron/main.ts',
-        vite: {
-          plugins: [loadEnvPlugin()],
-        },
       },
       {
         entry: 'electron/preload.ts',

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export { build }
 
 export default function electron(config: Configuration | Configuration[]): Plugin[] {
   const configArray = Array.isArray(config) ? config : [config]
+  let mode: string
 
   return [
     {
@@ -30,12 +31,15 @@ export default function electron(config: Configuration | Configuration[]): Plugi
     {
       name: 'vite-plugin-electron',
       apply: 'build',
-      config(config) {
+      config(config, env) {
         // Make sure that Electron can be loaded into the local file using `loadFile` after packaging.
         config.base ??= './'
+        mode = env.mode
       },
       async closeBundle() {
         for (const config of configArray) {
+          config.vite ??= {}
+          config.vite.mode ??= mode
           await build(config)
         }
       }


### PR DESCRIPTION
## 0.11.0 (2022-12-17)

#### Break!

```ts
// 0.10.0
function build(config: Configuration | Configuration[]): Promise<void>

// 0.11.0 - Same as Vite's build
function build(config: Configuration): Promise<RollupOutput | RollupOutput[] | RollupWatcher>
```

#### Features

**JavaScript API**

`vite-plugin-electron`'s JavaScript APIs are fully typed, and it's recommended to use TypeScript or enable JS type checking in VS Code to leverage the intellisense and validation.

- `Configuration` - type
- `defineConfig` - function
- `resolveViteConfig` - function, Resolve the default Vite's `InlineConfig` for build Electron-Main
- `withExternalBuiltins` - function
- `build` - function

Example:

```js
build(
  withExternalBuiltins( // external Node.js builtin modules
    resolveViteConfig( // with default config
      {
        entry: 'foo.ts',
        vite: {
          mode: 'foo-mode', // for .env file
          plugins: [{
            name: 'plugin-build-done',
            closeBundle() {
              // Do something...
            },
          }],
        },
      }
    )
  )
)
```

**V8 Bytecode support** 👉 [bytecode](https://github.com/electron-vite/vite-plugin-electron/tree/main/examples/bytecode)

Inspired by:

- [Nihiue/little-byte-demo](https://github.com/Nihiue/little-byte-demo)
- [通过字节码保护Node.js源码之原理篇 - 知乎](https://zhuanlan.zhihu.com/p/359235114)

#### Commit/PR

- Support Vite4.x | #118, 28d38b6
- Bytecode example | df170c2
- JavaScript API docs | 3049169
- Fix load `.env` | 758695d
- Refactor `build()` | d9c3343
