### PR TITLE
feat: allow to configure output file name format

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ export interface ElectronOptions {
    * Shortcut of `build.lib.entry`
    */
   entry?: import('vite').LibraryOptions['entry']
+  fileName?: import('vite').LibraryOptions['fileName']
   vite?: import('vite').InlineConfig
   /**
    * Triggered when Vite is built every time -- `vite serve` command only.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,7 +25,7 @@ export function resolveViteConfig(options: ElectronOptions): InlineConfig {
         entry: options.entry,
         // At present, Electron(20) can only support CommonJs
         formats: ['cjs'],
-        fileName: () => '[name].js',
+        fileName: options.fileName || (() => '[name].js'),
       },
       outDir: 'dist-electron',
       // Avoid multiple entries affecting each other


### PR DESCRIPTION
Hi,

Because i am using some esm module lib in `vite.config.ts`.
```ts
import mdx from '@mdx-js/rollup';
import remarkFrontmatter from 'remark-frontmatter';
import remarkMdxFrontmatter from 'remark-mdx-frontmatter';
```
So i needs to set the `type` in `package.json` to `module`, but after that electron is not able to start

I would like to add a new option to change the output file extension  to `cjs` so that i and execute the electron cli 
```ts
defineConfig({
    plugins: [ 
       electron({
         // ...
         fileName: () => `[named].cjs`
       })
   ]
})
```


```json
{
  "type": "module",
  "main": "dist-electron/main/index.cjs",
}
```