### PR TITLE
v0.14.0-beta.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,5 +109,4 @@ package-lock.json
 # pnpm-lock.yaml
 yarn.lock
 
-/plugin
 /types

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 0.14.0-beta.0 (2023-08-23)
+
+- d3cf87f feat: simple API build
+- d8c3c27 feat: simple API 🥳
+
+See **[👉 Simple API](https://github.com/electron-vite/vite-plugin-electron/tree/v0.14.0-beta.0#simple-api)**
+
+```js
+import electron from 'vite-plugin-electron/simple'
+
+electron({
+  main: {},
+  preload: {},
+  renderer: {},
+})
+```
+
 ## 0.13.0-beta.3 (2023-08-22)
 
 - 37e14b0 fix: remove `apply: 'serve'`

--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@
 
 ## Features
 
-- 🐣 Few APIs, easy to use
-- 🌱 Fully compatible with Vite and Vite's ecosystem <sub><sup>(Based on Vite)</sup></sub>
-- [🚀 Not Bundle, It's fast <sub><sup>(Like Vite's Not Bundle)</sup></sub>](https://github.com/electron-vite/vite-plugin-electron#not-bundle)
 - [🔥 Hot Restart <sub><sup>(Main process)</sup></sub>](https://electron-vite.github.io/guide/features.html#hot-restart)
 - [🔄 Hot Reload <sub><sup>(Preload scripts)</sup></sub>](https://electron-vite.github.io/guide/features.html#hot-reload)
 - [⚡️ HMR <sub><sup>(Renderer process)</sup></sub>](https://electron-vite.github.io/guide/features.html#hmr)
+- [🚀 Not Bundle, It's fast <sub><sup>(Like Vite's Not Bundle)</sup></sub>](https://github.com/electron-vite/vite-plugin-electron#not-bundle)
+- 🌱 Fully compatible with Vite and Vite's ecosystem <sub><sup>(Based on Vite)</sup></sub>
+- 🐣 Few APIs, easy to use
 
 <!-- ![vite-plugin-electron.gif](https://github.com/electron-vite/vite-plugin-electron/blob/main/vite-plugin-electron.gif?raw=true) -->
 
@@ -89,9 +89,33 @@ app.whenReady().then(() => {
 
 That's it! You can now use Electron in your Vite app ✨
 
+## Simple API
+
+Many times, for a developer who is new to Vite and Electron, the oversimplified and open API design is confusing to them. Maybe Simple API makes them easier to understand. :)
+
+```js
+import electron from 'vite-plugin-electron/simple'
+
+export default {
+  plugins: [
+    electron({
+      main: {
+        entry: 'electron/main.ts',
+      },
+      // Optional: input must be use absolute path
+      preload: {
+        input: __dirname + '/electron/preload.ts',
+      },
+      // Optional: Use Node.js API in the Renderer process
+      renderer: {},
+    }),
+  ],
+}
+```
+
 ## API <sub><sup>(Define)</sup></sub>
 
-`electron(config: ElectronOptions | ElectronOptions[])`
+`electron(options: ElectronOptions | ElectronOptions[])`
 
 ```ts
 export interface ElectronOptions {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-electron",
-  "version": "0.13.0-beta.3",
+  "version": "0.14.0-beta.0",
   "description": "Electron 🔗 Vite",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -11,9 +11,14 @@
       "require": "./dist/index.js"
     },
     "./plugin": {
-      "types": "./plugin/index.d.ts",
-      "import": "./plugin/index.mjs",
-      "require": "./plugin/index.js"
+      "types": "./dist/plugin.d.ts",
+      "import": "./dist/plugin.mjs",
+      "require": "./dist/plugin.js"
+    },
+    "./simple": {
+      "types": "./dist/simple.d.ts",
+      "import": "./dist/simple.mjs",
+      "require": "./dist/simple.js"
     },
     "./*": "./*"
   },
@@ -31,16 +36,26 @@
     "test": "vitest run",
     "prepublishOnly": "npm run build && npm run test"
   },
+  "peerDependencies": {
+    "vite-plugin-electron-renderer": "*"
+  },
+  "peerDependenciesMeta": {
+    "vite-plugin-electron-renderer": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "rollup": "^3.17.2",
     "typescript": "^4.9.5",
     "vite": "^4.1.4",
+    "vite-plugin-electron-renderer": "^0.14.5",
     "vitest": "^0.28.5"
   },
   "files": [
     "dist",
-    "plugin",
-    "electron-env.d.ts"
+    "electron-env.d.ts",
+    "plugin.d.ts",
+    "simple.d.ts"
   ],
   "keywords": [
     "vite",

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -1,0 +1,2 @@
+// For import intellisense
+export * from './dist/plugin'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,9 @@ importers:
       vite:
         specifier: ^4.1.4
         version: 4.1.4(@types/node@18.0.6)
+      vite-plugin-electron-renderer:
+        specifier: ^0.14.5
+        version: 0.14.5
       vitest:
         specifier: ^0.28.5
         version: 0.28.5
@@ -2263,6 +2266,10 @@ packages:
     resolution: {integrity: sha512-n0w8vrQFafaY1tmIPIQAck4zLanGLYcthvGttH00KRJg47Sjh2mp5Hb8VJ3l8FmpnYTobnl949+N4sunTR1WBA==}
     dependencies:
       lib-esm: 0.3.0
+    dev: true
+
+  /vite-plugin-electron-renderer@0.14.5:
+    resolution: {integrity: sha512-EQ7ORuPp8vFPCqfuGnVo7d36fXS0IFH4/RUlKb1drseix3TQEPcgwEuFADdXBxRgqMp70njz/1m0kdf5lEsm8w==}
     dev: true
 
   /vite-plugin-multiple@0.2.0:

--- a/simple.d.ts
+++ b/simple.d.ts
@@ -1,0 +1,4 @@
+// For import intellisense
+export * from './dist/simple'
+import simple from './dist/simple'
+export default simple

--- a/src/simple.ts
+++ b/src/simple.ts
@@ -1,0 +1,78 @@
+import {
+  type Plugin,
+  type UserConfig,
+  mergeConfig,
+} from 'vite'
+import type { InputOption } from 'rollup'
+import electron, { type ElectronOptions } from '.'
+
+export interface ElectronSimpleOptions {
+  main: ElectronOptions
+  preload?: Omit<ElectronOptions, 'entry'> & {
+    /**
+     * Shortcut of `build.rollupOptions.input`.
+     * 
+     * Preload scripts perhaps bundle as web format, so use the `build.rollupOptions.input` instead `build.lib.entry`.
+     */
+    input: InputOption
+  }
+  /**
+   * Support use Node.js API in Electron-Renderer
+   * @see https://github.com/electron-vite/vite-plugin-electron-renderer
+   */
+  renderer?: import('vite-plugin-electron-renderer').RendererOptions
+}
+
+// Vite v3.x support async plugin.
+export default async function electronSimple(options: ElectronSimpleOptions): Promise<Plugin[]> {
+  const opts = [options.main]
+  if (options.preload) {
+    const {
+      input,
+      vite: viteConfig = {},
+      ...preloadOptions
+    } = options.preload
+    const preload: ElectronOptions = {
+      onstart(args) {
+        // Notify the Renderer-Process to reload the page when the Preload-Scripts build is complete, 
+        // instead of restarting the entire Electron App.
+        args.reload()
+      },
+      ...preloadOptions,
+      vite: mergeConfig({
+        build: {
+          rollupOptions: {
+            input,
+            output: {
+              // Only one file will be bundled, which is consistent with the behavior of `build.lib`
+              manualChunks: {},
+              // https://github.com/vitejs/vite/blob/v4.4.9/packages/vite/src/node/build.ts#L604
+              entryFileNames: '[name].js',
+              chunkFileNames: '[name].js',
+              assetFileNames: '[name].[ext]',
+            },
+          },
+        } as UserConfig,
+      }, viteConfig),
+    }
+    opts.push(preload)
+  }
+  const plugins = electron(opts)
+
+  if (options.renderer) {
+    try {
+      const renderer = await import('vite-plugin-electron-renderer')
+      plugins.push(renderer.default(options.renderer))
+    } catch (error: any) {
+      if (error.code === 'ERR_MODULE_NOT_FOUND') {
+        throw new Error(
+          `\`renderer\` option dependency "vite-plugin-electron-renderer" not found. Did you install it? Try \`npm i -D vite-plugin-electron-renderer\`.`,
+        )
+      }
+
+      throw error
+    }
+  }
+
+  return plugins
+}

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -6,7 +6,7 @@ import {
   expect,
   it,
 } from 'vitest'
-import { notBundle } from '../plugin'
+import { notBundle } from '../dist/plugin'
 
 const pluginNotBundle = notBundle()
 pluginNotBundle.apply = undefined

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,11 +19,12 @@ export default defineConfig(() => {
     build: {
       minify: false,
       emptyOutDir: false,
-      outDir: '',
+      outDir: 'dist',
       lib: {
         entry: {
-          'dist/index': 'src/index.ts',
-          'plugin/index': 'src/plugin.ts',
+          index: 'src/index.ts',
+          plugin: 'src/plugin.ts',
+          simple: 'src/simple.ts',
         },
         formats: ['cjs', 'es'],
         fileName: format => format === 'es' ? '[name].mjs' : '[name].js',
@@ -32,6 +33,7 @@ export default defineConfig(() => {
         external: [
           'electron',
           'vite',
+          'vite-plugin-electron-renderer',
           ...builtinModules,
           ...builtinModules.map(m => `node:${m}`),
           ...Object.keys('dependencies' in pkg ? pkg.dependencies as object : {}),
@@ -77,13 +79,10 @@ function generateTypes() {
 function moveTypesToDist() {
   const types = path.join(__dirname, 'types')
   const dist = path.join(__dirname, 'dist')
-  const plugin = path.join(__dirname, 'plugin')
   const files = fs.readdirSync(types).filter(n => n.endsWith('.d.ts'))
   for (const file of files) {
     const from = path.join(types, file)
-    const to = file.includes('plugin.d.ts')
-      ? path.join(plugin, 'index.d.ts')
-      : path.join(dist, file)
+    const to = path.join(dist, file)
     fs.writeFileSync(to, fs.readFileSync(from, 'utf8'))
 
     const cwd = process.cwd()


### PR DESCRIPTION
## 0.14.0-beta.0 (2023-08-23)

- d3cf87f feat: simple API build
- d8c3c27 feat: simple API 🥳

See **[👉 Simple API](https://github.com/electron-vite/vite-plugin-electron/tree/v0.14.0-beta.0#simple-api)**

```js
import electron from 'vite-plugin-electron/simple'

electron({
  main: {},
  preload: {},
  renderer: {},
})
```
