### PR TITLE
feat: support electron 28

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,8 +18,7 @@ export function resolveViteConfig(options: ElectronOptions): InlineConfig {
       // @ts-ignore
       lib: options.entry && {
         entry: options.entry,
-        // At present, Electron(20) can only support CommonJs
-        formats: ['cjs'],
+        formats: ['es'],
         fileName: () => '[name].js',
       },
       outDir: 'dist-electron',


### PR DESCRIPTION
See https://github.com/electron/electron/blob/1bfa90c4ad922fdf9692e4fa7e32c508071544ef/docs/tutorial/esm-limitations.md, im going to fix them here

This will be breaking, because from now on everything will be esm.

Install beta

```
pnpm add electron@28.0.0-beta.4
```

Add

```
"type": "module",
"main": "dist-electron/main.js",
```

To your package.json

> `"module": "dist-electron/main.js"` should make more sense, but its only working with `main`...

Add to the plugins array in vite config

```typescript
electron({
  entry: 'src/electron/main.ts',
}),
```

electron-dist.js
```javascript
import { app, BrowserWindow } from "electron";
const createWindow = () => {
  const win = new BrowserWindow({
    width: 800,
    height: 600
  });
  win.loadURL("http://localhost:5173/");
};
app.whenReady().then(() => {
  createWindow();
});
```

<img width="839" alt="image" src="https://github.com/electron-vite/vite-plugin-electron/assets/12934957/f9f01206-0e69-4a06-98cd-4cf2452b65f1">