### PR TITLE
V0.28.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 0.28.1 (2024-02-06)
+
+- efc5826 fix: correct `calcEntryCount()` for startup
+- cf0e91f feat: startup support `SpawnOptions` #194
+- 512a1c5 Merge pull request #204 from SanGongHappy/tree-kill-sync
+- edf4bf6 refactor: better `treeKillSync` implemented
+- 82cd32f Merge branch 'electron-vite:main' into tree-kill-sync
+- 6e122a7 feat: polyfill `process.env` by default
+- 45f28bb (github/main, main) chore: update CHANGELOG
+- f9b81e4 chore(simple): update comments
+- b5376a9 docs: add `Built format`
+- e334366 copy tree-kill
+
 ## 0.28.0 (2024-01-07)
 
 - 20170a5 refactor: preload built `format` use `esm` by default

--- a/README.md
+++ b/README.md
@@ -137,17 +137,17 @@ export interface ElectronOptions {
   vite?: import('vite').InlineConfig
   /**
    * Triggered when Vite is built every time -- `vite serve` command only.
-   * 
-   * If this `onstart` is passed, Electron App will not start automatically.  
-   * However, you can start Electroo App via `startup` function.  
+   *
+   * If this `onstart` is passed, Electron App will not start automatically.
+   * However, you can start Electroo App via `startup` function.
    */
   onstart?: (args: {
     /**
-     * Electron App startup function.  
-     * It will mount the Electron App child-process to `process.electronApp`.  
+     * Electron App startup function.
+     * It will mount the Electron App child-process to `process.electronApp`.
      * @param argv default value `['.', '--no-sandbox']`
      */
-    startup: (argv?: string[]) => Promise<void>
+    startup: (argv?: string[], options?: import('node:child_process').SpawnOptions) => Promise<void>
     /** Reload Electron-Renderer */
     reload: () => void
   }) => void | Promise<void>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-electron",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "description": "Electron 🔗 Vite",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ export interface ElectronOptions {
      * It will mount the Electron App child-process to `process.electronApp`.
      * @param argv default value `['.', '--no-sandbox']`
      */
-    startup: (argv?: string[]) => Promise<void>
+    startup: (argv?: string[], options?: import('node:child_process').SpawnOptions) => Promise<void>
     /** Reload Electron-Renderer */
     reload: () => void
   }) => void | Promise<void>
@@ -120,7 +120,10 @@ export default function electron(options: ElectronOptions | ElectronOptions[]): 
  * It will mount the Electron App child-process to `process.electronApp`.
  * @param argv default value `['.', '--no-sandbox']`
  */
-export async function startup(argv = ['.', '--no-sandbox']) {
+export async function startup(
+  argv = ['.', '--no-sandbox'],
+  options?: import('node:child_process').SpawnOptions,
+) {
   const { spawn } = await import('node:child_process')
   // @ts-ignore
   const electron = await import('electron')
@@ -129,7 +132,7 @@ export async function startup(argv = ['.', '--no-sandbox']) {
   await startup.exit()
 
   // Start Electron.app
-  process.electronApp = spawn(electronPath, argv, { stdio: 'inherit' })
+  process.electronApp = spawn(electronPath, argv, { stdio: 'inherit', ...options })
 
   // Exit command after Electron.app exits
   process.electronApp.once('exit', process.exit)

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,6 @@ import {
   resolveServerUrl,
   resolveViteConfig,
   withExternalBuiltins,
-  calcEntryCount,
   treeKillSync,
 } from './utils'
 
@@ -58,7 +57,7 @@ export default function electron(options: ElectronOptions | ElectronOptions[]): 
             VITE_DEV_SERVER_URL: resolveServerUrl(server),
           })
 
-          const entryCount = calcEntryCount(optionsArray)
+          const entryCount = optionsArray.length
           let closeBundleCount = 0
 
           for (const options of optionsArray) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,6 +36,10 @@ export function resolveViteConfig(options: ElectronOptions): InlineConfig {
       // It corrupts bundling packages like `ws` and `isomorphic-ws`, for example.
       mainFields: ['module', 'jsnext:main', 'jsnext'],
     },
+    define: {
+      // @see - https://github.com/vitejs/vite/blob/v5.0.11/packages/vite/src/node/plugins/define.ts#L20
+      'process.env': 'process.env',
+    },
   }
 
   return mergeConfig(defaultConfig, options?.vite || {})

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -121,26 +121,6 @@ export function resolveServerUrl(server: ViteDevServer): string | void {
   }
 }
 
-export function calcEntryCount(optionsArray: ElectronOptions[]) {
-  return optionsArray.reduce((count, options) => {
-    const input = options.vite?.build?.rollupOptions?.input
-
-    // `input` option have higher priority.
-    // https://github.com/vitejs/vite/blob/v4.4.9/packages/vite/src/node/build.ts#L494
-    if (input) {
-      count += typeof input === 'string'
-        ? 1
-        : Object.keys(input).length
-    } else if (options.entry) {
-      count += typeof options.entry === 'string'
-        ? 1
-        : Object.keys(options.entry).length
-    }
-
-    return count
-  }, 0)
-}
-
 export function resolvePackageJson(root = process.cwd()): {
   type?: 'module' | 'commonjs'
   [key: string]: any


### PR DESCRIPTION
## 0.28.1 (2024-02-06)

- efc5826 fix: correct `calcEntryCount()` for startup
- cf0e91f feat: startup support `SpawnOptions` #194
- 512a1c5 Merge pull request #204 from SanGongHappy/tree-kill-sync
- edf4bf6 refactor: better `treeKillSync` implemented
- 82cd32f Merge branch 'electron-vite:main' into tree-kill-sync
- 6e122a7 feat: polyfill `process.env` by default
- 45f28bb (github/main, main) chore: update CHANGELOG
- f9b81e4 chore(simple): update comments
- b5376a9 docs: add `Built format`
- e334366 copy tree-kill
