### PR TITLE
V0.28.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.28.4 (2024-03-17)
+
+- 4f7748c chore: restore `vite-plugin-electron-renderer` in `peerDependencies`
+- 412ed9b fix(#214): catch the `process.kill(pid)` error
+
 ## 0.28.3 (2024-03-13)
 
 - a300c08 fix: remove electron@28 version pre-deps

--- a/package.json
+++ b/package.json
@@ -36,6 +36,14 @@
     "test": "vitest run",
     "prepublishOnly": "npm run build && npm run test"
   },
+  "peerDependencies": {
+    "vite-plugin-electron-renderer": "*"
+  },
+  "peerDependenciesMeta": {
+    "vite-plugin-electron-renderer": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "rollup": "^4.13.0",
     "typescript": "^5.4.2",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -172,5 +172,7 @@ function killTree(tree: PidTree) {
     }
   }
 
-  process.kill(tree.pid)
+  try {
+    process.kill(tree.pid) // #214
+  } catch { /* empty */ }
 }


### PR DESCRIPTION
## 0.28.4 (2024-03-17)

- 4f7748c chore: restore `vite-plugin-electron-renderer` in `peerDependencies`
- 412ed9b fix(#214): catch the `process.kill(pid)` error