### PR TITLE
v0.28.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.28.4 (2024-03-17)
+
+- 4f7748c chore: restore `vite-plugin-electron-renderer` in `peerDependencies`
+- 412ed9b fix(#214): catch the `process.kill(pid)` error
+
 ## 0.28.3 (2024-03-13)
 
 - a300c08 fix: remove electron@28 version pre-deps

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-electron",
-  "version": "0.28.3",
+  "version": "0.28.4",
   "description": "Electron 🔗 Vite",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## 0.28.4 (2024-03-17)

- 4f7748c chore: restore `vite-plugin-electron-renderer` in `peerDependencies`
- 412ed9b fix(#214): catch the `process.kill(pid)` error