### PR TITLE
Feat: Custom Electron Package Name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -118,14 +118,17 @@ export default function electron(options: ElectronOptions | ElectronOptions[]): 
  * Electron App startup function.
  * It will mount the Electron App child-process to `process.electronApp`.
  * @param argv default value `['.', '--no-sandbox']`
+ * @param options options for `child_process.spawn`
+ * @param customElectronPkg custom electron package name (default: 'electron')
  */
 export async function startup(
   argv = ['.', '--no-sandbox'],
   options?: import('node:child_process').SpawnOptions,
+  customElectronPkg?: string,
 ) {
   const { spawn } = await import('node:child_process')
   // @ts-ignore
-  const electron = await import('electron')
+  const electron = await import(customElectronPkg ?? 'electron')
   const electronPath = <any>(electron.default ?? electron)
 
   await startup.exit()


### PR DESCRIPTION
This PR allows the use of a custom package name to substitute the default `electron` package that is invoked. Several forks of Electron, including [Overwolf's custom one](https://overwolf.github.io/tools/ow-electron), change the package identifier therefor not working out of the box with this plugin. Instead of invoking `electron`, I wish to invoke `@overwolf/ow-electron`.