### PR TITLE
V0.28.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.28.6 (2024-04-21)
+
+- be94383 fix: `ElectronOptions['startup']` definition
+- 96905d9 chore: compatible vite@4 resolve node first
+- a16fe3c fix: hot-reload compatible vite@4
+
 ## 0.28.5 (2024-04-19)
 
 - f325403 chore: update comments

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ export interface ElectronOptions {
      * @param options options for `child_process.spawn`
      * @param customElectronPkg custom electron package name (default: 'electron')
      */
-    startup: (argv?: string[], options?: import('node:child_process').SpawnOptions) => Promise<void>
+    startup: (argv?: string[], options?: import('node:child_process').SpawnOptions, customElectronPkg?: string) => Promise<void>
     /** Reload Electron-Renderer */
     reload: () => void
   }) => void | Promise<void>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-electron",
-  "version": "0.28.5",
+  "version": "0.28.6",
   "description": "Electron 🔗 Vite",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,7 +80,7 @@ export default function electron(options: ElectronOptions | ElectronOptions[]): 
                       startup,
                       reload() {
                         if (process.electronApp) {
-                          server.hot.send({ type: 'full-reload' })
+                          (server.hot || server.ws).send({ type: 'full-reload' })
                         } else {
                           startup()
                         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ export interface ElectronOptions {
      * @param options options for `child_process.spawn`
      * @param customElectronPkg custom electron package name (default: 'electron')
      */
-    startup: (argv?: string[], options?: import('node:child_process').SpawnOptions) => Promise<void>
+    startup: (argv?: string[], options?: import('node:child_process').SpawnOptions, customElectronPkg?: string) => Promise<void>
     /** Reload Electron-Renderer */
     reload: () => void
   }) => void | Promise<void>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -38,6 +38,9 @@ export function resolveViteConfig(options: ElectronOptions): InlineConfig {
       emptyOutDir: false,
     },
     resolve: {
+      // @ts-ignore
+      browserField: false,
+      conditions: ['node'],
       // #98
       // Since we're building for electron (which uses Node.js), we don't want to use the "browser" field in the packages.
       // It corrupts bundling packages like `ws` and `isomorphic-ws`, for example.


### PR DESCRIPTION
## 0.28.6 (2024-04-21)

- be94383 fix: `ElectronOptions['startup']` definition
- 96905d9 chore: compatible vite@4 resolve node first
- a16fe3c fix: hot-reload compatible vite@4
