### PR TITLE
fix: notBundle test is failed

### DIFF
--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -10,6 +10,7 @@ import { notBundle } from '../dist/plugin'
 
 const pluginNotBundle = notBundle()
 pluginNotBundle.apply = undefined
+const normalizingNewLineRE = /[\r\n]+/g
 
 describe('src/plugin', () => {
   it('notBundle', async () => {
@@ -29,7 +30,9 @@ describe('src/plugin', () => {
 
     const distMain = fs.readFileSync(path.join(__dirname, '__snapshots__/external-main.js'), 'utf-8')
     const snapMain = fs.readFileSync(path.join(__dirname, 'dist/external-main.js'), 'utf-8')
+    const normalDistMain = distMain.replace(normalizingNewLineRE, '\n')
+    const normalSnapMain = snapMain.replace(normalizingNewLineRE, '\n')
 
-    expect(distMain).equal(snapMain)
+    expect(normalDistMain).equal(normalSnapMain)
   })
 })


### PR DESCRIPTION
环境：windows 11
node版本：v20.10.0
当我运行notBundle测试时会出现以下错误
```
 FAIL  test/plugin.test.ts > src/plugin > notBundle
AssertionError: expected '"use strict";\r\nvar __create = Objec…' to equal '"use strict";\nvar __create = Object.…'

- Expected
+ Received

- "use strict";
- var __create = Object.create;
- var __defProp = Object.defineProperty;
- var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
- var __getOwnPropNames = Object.getOwnPropertyNames;
- var __getProtoOf = Object.getPrototypeOf;
- var __hasOwnProp = Object.prototype.hasOwnProperty;
- var __copyProps = (to, from, except, desc) => {
-   if (from && typeof from === "object" || typeof from === "function") {
-     for (let key of __getOwnPropNames(from))
-       if (!__hasOwnProp.call(to, key) && key !== except)
-         __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
-   }
-   return to;
- };
- var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
-   // If the importer is in node compatibility mode or this is not an ESM
-   // file that has been converted to a CommonJS file using a Babel-
-   // compatible transform (i.e. "__esModule" has not been set), then set
-   // "default" to the CommonJS "module.exports" for node compatibility.
-   isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
-   mod
- ));
- const vite = require("vite");
- const message = "foo";
- console.log(import("vite"));
- console.log(vite);
- console.log(message);
+ "use strict";
+ var __create = Object.create;
+ var __defProp = Object.defineProperty;
+ var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+ var __getOwnPropNames = Object.getOwnPropertyNames;
+ var __getProtoOf = Object.getPrototypeOf;
+ var __hasOwnProp = Object.prototype.hasOwnProperty;
+ var __copyProps = (to, from, except, desc) => {
+   if (from && typeof from === "object" || typeof from === "function") {
+     for (let key of __getOwnPropNames(from))
+       if (!__hasOwnProp.call(to, key) && key !== except)
+         __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+   }
+   return to;
+ };
+ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+   // If the importer is in node compatibility mode or this is not an ESM
+   // file that has been converted to a CommonJS file using a Babel-
+   // compatible transform (i.e. "__esModule" has not been set), then set
+   // "default" to the CommonJS "module.exports" for node compatibility.
+   isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+   mod
+ ));
+ const vite = require("vite");
+ const message = "foo";
+ console.log(import("vite"));
+ console.log(vite);
+ console.log(message);


 ❯ test/plugin.test.ts:36:22
     34|     const normalSnapMain = snapMain.replace(normalizingNewLineRE, '\n')
     35|
     36|     expect(distMain).equal(snapMain)
       |                      ^
     37|   })
     38| })
```
经检查是因为两个文件的换行符不一致。
```__snapshots__/external-main.js```为```\r\n```，而生成出来的```dis/external-main.js```为```\n```
我个人认为，两个文件的差异只有不可见的换行符时，可以通过标准化换行符后进行测试，而不影响该测试原来的目的