### PR TITLE
V0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## 0.29.0 (2024-11-16)
+
+- 638d0f3 feat: support main process control hot-reload
+- c58fbf9 feat: mock index.html for support use the main process only
+
+**Hot Reload**
+
+Since `v0.29.0`, when preload scripts are rebuilt, they will send an `electron-vite&type=hot-reload` event to the main process.  
+If your App doesn't need a renderer process, this will give you **hot-reload**.
+
+```js
+// electron/main.ts
+
+process.on('message', (msg) => {
+  if (msg === 'electron-vite&type=hot-reload') {
+    for (const win of BrowserWindow.getAllWindows()) {
+      // Hot reload preload scripts
+      win.webContents.reload()
+    }
+  }
+})
+```
+
 ## 0.28.8 (2024-09-19)
 
 - 3239718 fix: better exit app #251

--- a/README.md
+++ b/README.md
@@ -246,6 +246,24 @@ build({
 })
 ```
 
+**Hot Reload**
+
+Since `v0.29.0`, when preload scripts are rebuilt, they will send an `electron-vite&type=hot-reload` event to the main process.  
+If your App doesn't need a renderer process, this will give you **hot-reload**.
+
+```js
+// electron/main.ts
+
+process.on('message', (msg) => {
+  if (msg === 'electron-vite&type=hot-reload') {
+    for (const win of BrowserWindow.getAllWindows()) {
+      // Hot reload preload scripts
+      win.webContents.reload()
+    }
+  }
+})
+```
+
 ## How to work
 
 It just executes the `electron .` command in the Vite build completion hook and then starts or restarts the Electron App.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-electron",
-  "version": "0.28.8",
+  "version": "0.29.0",
   "description": "Electron 🔗 Vite",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -26,7 +26,7 @@
     "type": "git",
     "url": "git+https://github.com/electron-vite/vite-plugin-electron.git"
   },
-  "author": "草鞋没号 <308487730@qq.com>",
+  "author": "Leo Wang(草鞋没号) <308487730@qq.com>",
   "license": "MIT",
   "packageManager": "pnpm@8.0.0",
   "scripts": {


### PR DESCRIPTION
## 0.29.0 (2024-11-16)

- 638d0f3 feat: support main process control hot-reload
- c58fbf9 feat: mock index.html for support use the main process only

**Hot Reload**

Since `v0.29.0`, when preload scripts are rebuilt, they will send an `electron-vite&type=hot-reload` event to the main process.  
If your App doesn't need a renderer process, this will give you **hot-reload**.

```js
// electron/main.ts

process.on('message', (msg) => {
  if (msg === 'electron-vite&type=hot-reload') {
    for (const win of BrowserWindow.getAllWindows()) {
      // Hot reload preload scripts
      win.webContents.reload()
    }
  }
})
```

**Closes #128 , Support an App without a renderer process.**
