### PR TITLE
Avoid file descriptor 3 for IPC on Linux to prevent Chromium collision

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -168,8 +168,14 @@ export async function startup(
   await startup.exit()
 
   // Start Electron.app
+  const stdio =
+    process.platform === 'linux'
+      // reserve file descriptor 3 for Chromium; put Node IPC on file descriptor 4
+      ? ['inherit', 'inherit', 'inherit', 'ignore', 'ipc']
+      : ['inherit', 'inherit', 'inherit', 'ipc']
+
   process.electronApp = spawn(electronPath, argv, {
-    stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
+    stdio,
     ...options,
   })
 


### PR DESCRIPTION
Chromium/Electron on Linux assumes file descriptor 3 is its lowest reserved control pipe in several places (e.g., Crashpad handler plumbing) and, when used, DevTools’ `--remote-debugging-pipe` also binds file descriptors 3/4. If FD 3 is already a Node IPC pipe, the Chromium side can’t set up what it expects, and DevTools misbehaves. By inserting an `ignore` entry at index 3, we keep FD free for Chromium and put Node’s IPC on FD 4. The IPC-based feature from PR #260 continues to work normally via `child.send/process.on('message')`.

Fixes #264

CC @caoxiemeihao