### PR TITLE
fix: handle already-exited process on Windows during hot reload

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -108,11 +108,23 @@ startup.exit = async () => {
   if (process.electronApp) {
     await new Promise((resolve) => {
       process.electronApp.removeAllListeners()
+      
+      if (process.electronApp.exitCode !== null) {
+        resolve(undefined)
+        return
+      }
       process.electronApp.once('exit', resolve)
-      treeKillSync(process.electronApp.pid!)
+
+       try {
+        treeKillSync(process.electronApp.pid!)
+      } catch (_) {
+        // Windows: taskkill exit code 128 = process already gone
+        resolve(undefined)
+      }
     })
   }
 }
+
 
 export interface ElectronOptions {
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,23 +108,22 @@ startup.exit = async () => {
   if (process.electronApp) {
     await new Promise((resolve) => {
       process.electronApp.removeAllListeners()
-      
+
       if (process.electronApp.exitCode !== null) {
         resolve(undefined)
         return
       }
       process.electronApp.once('exit', resolve)
 
-       try {
+      try {
         treeKillSync(process.electronApp.pid!)
-      } catch (_) {
+      } catch {
         // Windows: taskkill exit code 128 = process already gone
         resolve(undefined)
       }
     })
   }
 }
-
 
 export interface ElectronOptions {
   /**


### PR DESCRIPTION
## Problem
On Windows, when a file change triggers a hot reload, `treeKillSync` 
attempts to kill the old Electron process. If the process has already 
exited, `taskkill` returns exit code 128 ("process not found"), which 
causes Node.js to throw an unhandled error and crash the dev server.

## Root Cause
Race condition between Electron process exit and the kill signal.
macOS/Linux are unaffected as they handle missing PIDs gracefully.

## Fix
Wrap `treeKillSync` call in try/catch to silently ignore the error 
when the process has already exited.

## Reproduction
1. Windows + vite-plugin-electron
2. Run dev server
3. Make rapid file changes
4. Observe crash with `ERROR: The process "XXXXX" not found.`